### PR TITLE
Chapter List Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@vaadin/virtual-list": "24.1.4",
     "construct-style-sheets-polyfill": "3.1.0",
     "date-fns": "2.29.3",
-    "lit": "2.7.6",
+    "lit": "2.6.1",
     "lumo-css-framework": "3.0.11",
     "mobile-drag-drop": "2.3.0-rc.2",
     "swiper": "^10.0.3",
@@ -86,12 +86,12 @@
     "rollup-plugin-visualizer": "5.9.0",
     "strip-css-comments": "5.0.0",
     "transform-ast": "2.4.4",
-    "typescript": "5.0.4",
-    "vite": "4.3.9",
+    "typescript": "4.9.5",
+    "vite": "4.1.3",
     "vite-plugin-checker": "0.5.5",
-    "workbox-build": "7.0.0",
-    "workbox-core": "7.0.0",
-    "workbox-precaching": "7.0.0"
+    "workbox-build": "6.5.4",
+    "workbox-core": "6.5.4",
+    "workbox-precaching": "6.5.4"
   },
   "vaadin": {
     "dependencies": {
@@ -161,7 +161,7 @@
       "@vaadin/virtual-list": "24.1.4",
       "construct-style-sheets-polyfill": "3.1.0",
       "date-fns": "2.29.3",
-      "lit": "2.7.6",
+      "lit": "2.6.1",
       "lumo-css-framework": "3.0.11",
       "mobile-drag-drop": "2.3.0-rc.2",
       "swiper": "^10.0.3",
@@ -178,12 +178,12 @@
       "rollup-plugin-visualizer": "5.9.0",
       "strip-css-comments": "5.0.0",
       "transform-ast": "2.4.4",
-      "typescript": "5.0.4",
-      "vite": "4.3.9",
+      "typescript": "4.9.5",
+      "vite": "4.1.3",
       "vite-plugin-checker": "0.5.5",
-      "workbox-build": "7.0.0",
-      "workbox-core": "7.0.0",
-      "workbox-precaching": "7.0.0"
+      "workbox-build": "6.5.4",
+      "workbox-core": "6.5.4",
+      "workbox-precaching": "6.5.4"
     },
     "hash": "054a00381cb651d8beb1470b6c2a06241ee209fff825df329a0337409c9a67d0"
   },

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterListBox.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterListBox.java
@@ -22,7 +22,7 @@ public class ChapterListBox extends ListBox<Chapter> {
 
           RouteParam mangaIdParam = new RouteParam("mangaId", String.valueOf(mangaId));
 
-          double chapterNumber = e.getValue().getChapterNumber();
+          double chapterNumber = e.getValue().getIndex();
           RouteParam chapterIndexParam;
           if (chapterNumber % 1 == 0) {
             chapterIndexParam = new RouteParam("chapterIndex", String.valueOf((int) chapterNumber));

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -22,7 +22,6 @@ import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import online.hatsunemiku.tachideskvaadinui.services.AniListAPIService;
 import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
-import online.hatsunemiku.tachideskvaadinui.utils.MangaDataUtils;
 import online.hatsunemiku.tachideskvaadinui.view.layout.StandardLayout;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.web.client.RestTemplate;
@@ -60,6 +59,8 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
 
     String id = idParam.get();
 
+    long mangaId = Long.parseLong(id);
+
     Manga manga;
     try {
       manga = getManga(settings, id);
@@ -83,7 +84,7 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     imageContainer.addClassName("manga-image-container");
     imageContainer.add(image);
 
-    ListBox<Chapter> chapters = getChapters(settings, id);
+    ListBox<Chapter> chapters = getChapters(mangaId);
 
     Div buttons = getButtons(manga);
 
@@ -151,9 +152,9 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     return manga;
   }
 
-  private ListBox<Chapter> getChapters(Settings settings, String mangaId) {
+  private ListBox<Chapter> getChapters(long mangaId) {
 
-    List<Chapter> chapter = MangaDataUtils.getChapterList(settings, mangaId, client);
+    List<Chapter> chapter = mangaService.getChapterList(mangaId);
 
     return new ChapterListBox(chapter);
   }


### PR DESCRIPTION
When having a prologue chapter (usually marked chapter **0**) it would result in an Exception being thrown, because of the chapter number being used instead of the index. This has been fixed with this PR.
MangaDataUtils was also replaced by the newer MangaService class in MangaView.java

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>