### PR TITLE
Manga Reader Tracking fix

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/reader/MangaReader.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/reader/MangaReader.java
@@ -18,6 +18,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
+import online.hatsunemiku.tachideskvaadinui.data.tracking.Tracker;
 import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
 import online.hatsunemiku.tachideskvaadinui.services.TrackingService;
@@ -201,14 +202,18 @@ public class MangaReader extends Div {
 
       loadChapter();
 
-      swiper.addActiveIndexChangeEventListener(
-          e -> {
-            if (e.getActiveIndex() == chapter.getPageCount() - 1) {
-              log.info("Last page of chapter {}", chapter.getIndex());
-              trackingService.setChapterProgress(chapter.getMangaId(), chapter.getIndex(), true);
-              e.unregisterListener();
-            }
-          });
+      Tracker tracker = settingsService.getSettings().getTracker(chapter.getMangaId());
+
+      if (tracker.hasAniListId()) {
+        swiper.addActiveIndexChangeEventListener(
+            e -> {
+              if (e.getActiveIndex() == chapter.getPageCount() - 1) {
+                log.info("Last page of chapter {}", chapter.getIndex());
+                trackingService.setChapterProgress(chapter.getMangaId(), chapter.getIndex(), true);
+                e.unregisterListener();
+              }
+            });
+      }
 
       add(swiper);
     }


### PR DESCRIPTION
MangaReader#Reader now checks whether the Manga is tracked before adding the respective listener

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>