### PR TITLE
Add library update button and related functionalities

### DIFF
--- a/frontend/css/root.css
+++ b/frontend/css/root.css
@@ -18,3 +18,10 @@
 .delete-category-button:hover {
   border: transparent;
 }
+
+.library-buttons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/LibUpdateService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/LibUpdateService.java
@@ -1,0 +1,27 @@
+package online.hatsunemiku.tachideskvaadinui.services;
+
+import java.net.URI;
+import online.hatsunemiku.tachideskvaadinui.services.client.LibUpdateClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LibUpdateService {
+
+  private final SettingsService settingsService;
+  private final LibUpdateClient client;
+
+  public LibUpdateService(SettingsService settingsService, LibUpdateClient client) {
+    this.settingsService = settingsService;
+    this.client = client;
+  }
+
+  public boolean fetchUpdate() {
+    var settings = settingsService.getSettings();
+
+    URI baseUrl = URI.create(settings.getUrl());
+
+    var response = client.fetchUpdate(baseUrl);
+
+    return response.getStatusCode().is2xxSuccessful();
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/LibUpdateClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/LibUpdateClient.java
@@ -1,0 +1,13 @@
+package online.hatsunemiku.tachideskvaadinui.services.client;
+
+import java.net.URI;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "lib-update-client", url = "http://localhost:8080")
+public interface LibUpdateClient {
+
+  @PostMapping("/api/v1/update/fetch")
+  ResponseEntity<Void> fetchUpdate(URI baseUrl);
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -38,7 +38,8 @@ public class RootView extends StandardLayout {
   private TabSheet tabs;
   private final LibUpdateService libUpdateService;
 
-  public RootView(RestTemplate client, SettingsService settingsService, LibUpdateService libUpdateService) {
+  public RootView(
+      RestTemplate client, SettingsService settingsService, LibUpdateService libUpdateService) {
     super("Library");
 
     this.client = client;
@@ -92,18 +93,19 @@ public class RootView extends StandardLayout {
         });
 
     Button refreshButton = new Button(VaadinIcon.REFRESH.create());
-    refreshButton.addClickListener(e -> {
-      boolean success = this.libUpdateService.fetchUpdate();
-      Notification notification;
-      if (!success) {
-        notification = new Notification("Failed to fetch update", 3000);
-        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-      } else {
-        notification = new Notification("Updating library", 3000);
-        notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
-      }
-      notification.open();
-    });
+    refreshButton.addClickListener(
+        e -> {
+          boolean success = this.libUpdateService.fetchUpdate();
+          Notification notification;
+          if (!success) {
+            notification = new Notification("Failed to fetch update", 3000);
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+          } else {
+            notification = new Notification("Updating library", 3000);
+            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+          }
+          notification.open();
+        });
 
     buttons.add(refreshButton, createButton);
 


### PR DESCRIPTION
Added a new button in the library UI for refreshing the library data with a new library update functionality. Introduced a new service, LibUpdateService which is responsible for fetching the updates. This was necessary to provide users with an intuitive way to update their library content, ensuring they always have the latest manga data available. Alongside, CSS changes are also implemented to provide a nice UI.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>