### PR TITLE
Update Chapter upload date formatting

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -25,9 +25,17 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
     title.setText("Chapter " + chapter.getChapterNumber());
     title.setClassName("chapter-list-box-item-title");
 
-    Date uploadDate = new Date(chapter.getUploadDate());
-    SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
-    String formattedDate = formatter.format(uploadDate);
+    long dateLong = chapter.getUploadDate();
+
+    String formattedDate;
+
+    if (dateLong == 0) {
+      formattedDate = "Today";
+    } else {
+      Date uploadDate = new Date(chapter.getUploadDate());
+      SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
+      formattedDate = formatter.format(uploadDate);
+    }
 
     Div date = new Div();
     date.setText(formattedDate);


### PR DESCRIPTION
Updated the way chapter upload dates are being formatted in ChapterRenderer. This change accommodates instances where the upload date is not set (i.e., denoted by '0') by defaulting to "Today" instead of attempting to format it. This resolves potential errors for date formatting.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>