### PR TITLE
Update LangComboBox event condition logic

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/combo/LangComboBox.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/combo/LangComboBox.java
@@ -48,14 +48,14 @@ public class LangComboBox extends ComboBox<String>
     boolean langsExist = !event.getLanguages().isEmpty();
 
     ui.access(
-            () -> {
-              setItems(event.getLanguages());
+        () -> {
+          setItems(event.getLanguages());
 
-              if (currentVal != null && event.getLanguages().contains(currentVal)) {
-                setValue(currentVal);
-              }
+          if (currentVal != null && event.getLanguages().contains(currentVal)) {
+            setValue(currentVal);
+          }
 
-              setEnabled(langsExist);
-            });
+          setEnabled(langsExist);
+        });
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/combo/LangComboBox.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/combo/LangComboBox.java
@@ -30,18 +30,24 @@ public class LangComboBox extends ComboBox<String>
   public void onComponentEvent(LanguageListChangeEvent event) {
     String currentVal = getValue();
 
+    UI ui;
+
     if (getUI().isEmpty()) {
-      return;
+      if (UI.getCurrent() == null) {
+        return;
+      }
+
+      ui = UI.getCurrent();
+    } else {
+      ui = getUI().get();
     }
 
-    if (!getUI().get().isAttached()) {
+    if (!ui.isAttached()) {
       return;
     }
     boolean langsExist = !event.getLanguages().isEmpty();
 
-    getUI()
-        .get()
-        .access(
+    ui.access(
             () -> {
               setItems(event.getLanguages());
 


### PR DESCRIPTION
Refactored LangComboBox event condition logic to handle scenarios when UI is not available. Existing implementation was exiting prematurely without consideration for cases when the UI could be fetched from UI.getCurrent(). The new approach helps to provide a robust way of accessing UI whether it's directly associated or requires to be fetched from UI.getCurrent().

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>