### PR TITLE
Add logging and improve process termination for TachideskStarter

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -33,10 +33,11 @@ public class TachideskStarter {
     File serverDirFile = new File(serverDir);
     File dataDirFile = new File(serverDirFile, "data");
 
-    String dataDirArg = "-Dsuwayomi.tachidesk.config.server.rootDir=" + dataDirFile.getAbsolutePath();
+    String dataDirArg =
+        "-Dsuwayomi.tachidesk.config.server.rootDir=" + dataDirFile.getAbsolutePath();
 
     ProcessBuilder processBuilder = new ProcessBuilder("java", dataDirArg, "-jar", jarLocation);
-    
+
     try {
       serverProcess = processBuilder.start();
       Runtime.getRuntime().addShutdownHook(new Thread(this::stopJar));

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -3,6 +3,7 @@ package online.hatsunemiku.tachideskvaadinui.startup;
 import jakarta.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.data.Meta;
 import online.hatsunemiku.tachideskvaadinui.utils.SerializationUtils;
 import org.slf4j.Logger;
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class TachideskStarter {
 
   private static final Logger logger = LoggerFactory.getLogger(TachideskStarter.class);
@@ -34,9 +36,10 @@ public class TachideskStarter {
     String dataDirArg = "-Dsuwayomi.tachidesk.config.server.rootDir=" + dataDirFile.getAbsolutePath();
 
     ProcessBuilder processBuilder = new ProcessBuilder("java", dataDirArg, "-jar", jarLocation);
-    processBuilder.inheritIO();
+    
     try {
       serverProcess = processBuilder.start();
+      Runtime.getRuntime().addShutdownHook(new Thread(this::stopJar));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -44,8 +47,15 @@ public class TachideskStarter {
 
   @PreDestroy
   public void stopJar() {
-    if (serverProcess != null) {
+    log.info("Stopping Jar");
+    if (serverProcess == null) {
+      return;
+    }
+
+    if (serverProcess.supportsNormalTermination()) {
       serverProcess.destroy();
+    } else {
+      serverProcess.destroyForcibly();
     }
   }
 


### PR DESCRIPTION
Added Slf4j logging to TachideskStarter and enhanced server process termination procedure. Logging provides real-time status updates and better visibility for debugging. Previously, the server process was forcibly terminated regardless of the circumstances, which could lead to abrupt shutdowns. Now, the normal termination is attempted before forcing a shutdown in order to ensure a more graceful exit where possible. This approach minimizes the risk of data loss or corruption.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>