### PR TITLE
Add read/unread status change functionality to chapter list

### DIFF
--- a/frontend/css/components/chapter-list-box.css
+++ b/frontend/css/components/chapter-list-box.css
@@ -21,15 +21,16 @@
 }
 
 .chapter-list-box-item-date {
-  font-size: 1em;
+  font-size: 1rem;
   color: var(--lumo-header-text-color);
   z-index: 2;
   padding-right: 1rem;
+  padding-left: 0.5rem;
+  font-weight: bold;
 }
 
 .chapter-list-box-item-read .chapter-list-box-item-date {
   color: var(--miku-unselected-color-50);
-  font-weight: bold;
 }
 
 .chapter-list-box-item-background {
@@ -38,4 +39,14 @@
   height: 100%;
   background: rgba(255,255,255,0.1);
   filter: blur(2px);
+}
+
+.chapter-list-box-item-right-side {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.chapter-list-box-item-right-side vaadin-button {
+  border: none;
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterListBox.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterListBox.java
@@ -1,14 +1,10 @@
 package online.hatsunemiku.tachideskvaadinui.component.listbox.chapter;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.listbox.ListBox;
-import com.vaadin.flow.router.RouteParam;
-import com.vaadin.flow.router.RouteParameters;
 import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
 import online.hatsunemiku.tachideskvaadinui.services.MangaService;
-import online.hatsunemiku.tachideskvaadinui.view.ReadingView;
 
 @CssImport("./css/components/chapter-list-box.css")
 public class ChapterListBox extends ListBox<Chapter> {
@@ -17,9 +13,5 @@ public class ChapterListBox extends ListBox<Chapter> {
     super();
     setItems(chapters);
     setRenderer(new ChapterRenderer(mangaService));
-    addValueChangeListener(
-        e -> {
-
-        });
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterListBox.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterListBox.java
@@ -7,32 +7,19 @@ import com.vaadin.flow.router.RouteParam;
 import com.vaadin.flow.router.RouteParameters;
 import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
+import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 import online.hatsunemiku.tachideskvaadinui.view.ReadingView;
 
 @CssImport("./css/components/chapter-list-box.css")
 public class ChapterListBox extends ListBox<Chapter> {
 
-  public ChapterListBox(List<Chapter> chapters) {
+  public ChapterListBox(List<Chapter> chapters, MangaService mangaService) {
     super();
     setItems(chapters);
-    setRenderer(new ChapterRenderer());
+    setRenderer(new ChapterRenderer(mangaService));
     addValueChangeListener(
         e -> {
-          int mangaId = e.getValue().getMangaId();
 
-          RouteParam mangaIdParam = new RouteParam("mangaId", String.valueOf(mangaId));
-
-          double chapterNumber = e.getValue().getIndex();
-          RouteParam chapterIndexParam;
-          if (chapterNumber % 1 == 0) {
-            chapterIndexParam = new RouteParam("chapterIndex", String.valueOf((int) chapterNumber));
-          } else {
-            chapterIndexParam = new RouteParam("chapterIndex", String.valueOf(chapterNumber));
-          }
-
-          RouteParameters params = new RouteParameters(mangaIdParam, chapterIndexParam);
-
-          UI.getCurrent().navigate(ReadingView.class, params);
         });
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -5,6 +5,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.RouteParam;
@@ -106,7 +108,14 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
   private static Button getReadButton(Chapter chapter, MangaService mangaService, Div rightSide) {
     Button readButton = new Button(VaadinIcon.EYE.create());
     readButton.addClickListener(e -> {
-      mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex());
+      if (mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex())) {
+        log.error("Failed to set chapter read");
+        Notification notification = new Notification("Failed to set chapter read", 5000);
+        notification.setPosition(Notification.Position.MIDDLE);
+        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+        notification.open();
+        return;
+      }
 
       Button unreadBtn = getUnreadButton(chapter, mangaService, rightSide);
       rightSide.replace(readButton, unreadBtn);
@@ -121,7 +130,14 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
   private static Button getUnreadButton(Chapter chapter, MangaService mangaService, Div rightSide) {
     Button unreadButton = new Button(VaadinIcon.EYE_SLASH.create());
     unreadButton.addClickListener(e -> {
-      mangaService.setChapterUnread(chapter.getMangaId(), chapter.getIndex());
+      if (!mangaService.setChapterUnread(chapter.getMangaId(), chapter.getIndex())) {
+        log.error("Failed to set chapter unread");
+        Notification notification = new Notification("Failed to set chapter unread", 5000);
+        notification.setPosition(Notification.Position.MIDDLE);
+        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+        notification.open();
+        return;
+      }
       Button readBtn = getReadButton(chapter, mangaService, rightSide);
       rightSide.replace(unreadButton, readBtn);
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -69,14 +69,17 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
 
     container.add(title, rightSide);
 
-    ComponentUtil.addListener(rightSide, ChapterReadStatusChangeEvent.class, e -> {
-      log.debug("ChapterReadStatusChangeEvent received");
-      if (e.isRead()) {
-        addReadStatus(container);
-      } else {
-        removeReadStatus(container);
-      }
-    });
+    ComponentUtil.addListener(
+        rightSide,
+        ChapterReadStatusChangeEvent.class,
+        e -> {
+          log.debug("ChapterReadStatusChangeEvent received");
+          if (e.isRead()) {
+            addReadStatus(container);
+          } else {
+            removeReadStatus(container);
+          }
+        });
 
     return container;
   }
@@ -84,66 +87,69 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
   @NotNull
   private static Div getChapterBackgroundDiv(Chapter chapter) {
     Div background = new Div();
-    background.addClickListener(e -> {
-      int mangaId = chapter.getMangaId();
+    background.addClickListener(
+        e -> {
+          int mangaId = chapter.getMangaId();
 
-      RouteParam mangaIdParam = new RouteParam("mangaId", String.valueOf(mangaId));
+          RouteParam mangaIdParam = new RouteParam("mangaId", String.valueOf(mangaId));
 
-      double chapterNumber = chapter.getIndex();
-      RouteParam chapterIndexParam;
-      if (chapterNumber % 1 == 0) {
-        chapterIndexParam = new RouteParam("chapterIndex", String.valueOf((int) chapterNumber));
-      } else {
-        chapterIndexParam = new RouteParam("chapterIndex", String.valueOf(chapterNumber));
-      }
+          double chapterNumber = chapter.getIndex();
+          RouteParam chapterIndexParam;
+          if (chapterNumber % 1 == 0) {
+            chapterIndexParam = new RouteParam("chapterIndex", String.valueOf((int) chapterNumber));
+          } else {
+            chapterIndexParam = new RouteParam("chapterIndex", String.valueOf(chapterNumber));
+          }
 
-      RouteParameters params = new RouteParameters(mangaIdParam, chapterIndexParam);
+          RouteParameters params = new RouteParameters(mangaIdParam, chapterIndexParam);
 
-      UI.getCurrent().navigate(ReadingView.class, params);
-    });
+          UI.getCurrent().navigate(ReadingView.class, params);
+        });
     background.setClassName("chapter-list-box-item-background");
     return background;
   }
 
   private static Button getReadButton(Chapter chapter, MangaService mangaService, Div rightSide) {
     Button readButton = new Button(VaadinIcon.EYE.create());
-    readButton.addClickListener(e -> {
-      if (mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex())) {
-        log.error("Failed to set chapter read");
-        Notification notification = new Notification("Failed to set chapter read", 5000);
-        notification.setPosition(Notification.Position.MIDDLE);
-        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-        notification.open();
-        return;
-      }
+    readButton.addClickListener(
+        e -> {
+          if (mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex())) {
+            log.error("Failed to set chapter read");
+            Notification notification = new Notification("Failed to set chapter read", 5000);
+            notification.setPosition(Notification.Position.MIDDLE);
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+            notification.open();
+            return;
+          }
 
-      Button unreadBtn = getUnreadButton(chapter, mangaService, rightSide);
-      rightSide.replace(readButton, unreadBtn);
+          Button unreadBtn = getUnreadButton(chapter, mangaService, rightSide);
+          rightSide.replace(readButton, unreadBtn);
 
-      var readEvent = new ChapterReadStatusChangeEvent(readButton,true, true);
-      ComponentUtil.fireEvent(rightSide, readEvent);
-    });
+          var readEvent = new ChapterReadStatusChangeEvent(readButton, true, true);
+          ComponentUtil.fireEvent(rightSide, readEvent);
+        });
 
     return readButton;
   }
 
   private static Button getUnreadButton(Chapter chapter, MangaService mangaService, Div rightSide) {
     Button unreadButton = new Button(VaadinIcon.EYE_SLASH.create());
-    unreadButton.addClickListener(e -> {
-      if (!mangaService.setChapterUnread(chapter.getMangaId(), chapter.getIndex())) {
-        log.error("Failed to set chapter unread");
-        Notification notification = new Notification("Failed to set chapter unread", 5000);
-        notification.setPosition(Notification.Position.MIDDLE);
-        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-        notification.open();
-        return;
-      }
-      Button readBtn = getReadButton(chapter, mangaService, rightSide);
-      rightSide.replace(unreadButton, readBtn);
+    unreadButton.addClickListener(
+        e -> {
+          if (!mangaService.setChapterUnread(chapter.getMangaId(), chapter.getIndex())) {
+            log.error("Failed to set chapter unread");
+            Notification notification = new Notification("Failed to set chapter unread", 5000);
+            notification.setPosition(Notification.Position.MIDDLE);
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+            notification.open();
+            return;
+          }
+          Button readBtn = getReadButton(chapter, mangaService, rightSide);
+          rightSide.replace(unreadButton, readBtn);
 
-      var readEvent = new ChapterReadStatusChangeEvent(unreadButton,true, false);
-      ComponentUtil.fireEvent(rightSide, readEvent);
-    });
+          var readEvent = new ChapterReadStatusChangeEvent(unreadButton, true, false);
+          ComponentUtil.fireEvent(rightSide, readEvent);
+        });
 
     return unreadButton;
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -1,24 +1,35 @@
 package online.hatsunemiku.tachideskvaadinui.component.listbox.chapter;
 
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.RouteParam;
+import com.vaadin.flow.router.RouteParameters;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import online.hatsunemiku.tachideskvaadinui.component.listbox.chapter.event.ChapterReadStatusChangeEvent;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
+import online.hatsunemiku.tachideskvaadinui.services.MangaService;
+import online.hatsunemiku.tachideskvaadinui.view.ReadingView;
+import org.jetbrains.annotations.NotNull;
 
+@Slf4j
 public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter> {
 
-  public ChapterRenderer() {
-    super(ChapterRenderer::createPresentation);
+  public ChapterRenderer(MangaService mangaService) {
+    super(chapter -> createPresentation(chapter, mangaService));
   }
 
-  private static HorizontalLayout createPresentation(Chapter chapter) {
+  private static HorizontalLayout createPresentation(Chapter chapter, MangaService mangaService) {
     HorizontalLayout container = new HorizontalLayout();
     container.addClassName("chapter-list-box-item");
 
-    Div background = new Div();
-    background.setClassName("chapter-list-box-item-background");
+    Div background = getChapterBackgroundDiv(chapter);
     container.add(background);
 
     Div title = new Div();
@@ -41,12 +52,91 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
     date.setText(formattedDate);
     date.setClassName("chapter-list-box-item-date");
 
-    container.add(title, date);
+    Div rightSide = new Div();
+    rightSide.addClassName("chapter-list-box-item-right-side");
 
-    if (chapter.isRead()) {
-      container.addClassName("chapter-list-box-item-read");
+    Button readStatusBtn;
+    if (!chapter.isRead()) {
+      readStatusBtn = getReadButton(chapter, mangaService, rightSide);
+    } else {
+      addReadStatus(container);
+      readStatusBtn = getUnreadButton(chapter, mangaService, rightSide);
     }
 
+    rightSide.add(readStatusBtn, date);
+
+    container.add(title, rightSide);
+
+    ComponentUtil.addListener(rightSide, ChapterReadStatusChangeEvent.class, e -> {
+      log.debug("ChapterReadStatusChangeEvent received");
+      if (e.isRead()) {
+        addReadStatus(container);
+      } else {
+        removeReadStatus(container);
+      }
+    });
+
     return container;
+  }
+
+  @NotNull
+  private static Div getChapterBackgroundDiv(Chapter chapter) {
+    Div background = new Div();
+    background.addClickListener(e -> {
+      int mangaId = chapter.getMangaId();
+
+      RouteParam mangaIdParam = new RouteParam("mangaId", String.valueOf(mangaId));
+
+      double chapterNumber = chapter.getIndex();
+      RouteParam chapterIndexParam;
+      if (chapterNumber % 1 == 0) {
+        chapterIndexParam = new RouteParam("chapterIndex", String.valueOf((int) chapterNumber));
+      } else {
+        chapterIndexParam = new RouteParam("chapterIndex", String.valueOf(chapterNumber));
+      }
+
+      RouteParameters params = new RouteParameters(mangaIdParam, chapterIndexParam);
+
+      UI.getCurrent().navigate(ReadingView.class, params);
+    });
+    background.setClassName("chapter-list-box-item-background");
+    return background;
+  }
+
+  private static Button getReadButton(Chapter chapter, MangaService mangaService, Div rightSide) {
+    Button readButton = new Button(VaadinIcon.EYE.create());
+    readButton.addClickListener(e -> {
+      mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex());
+
+      Button unreadBtn = getUnreadButton(chapter, mangaService, rightSide);
+      rightSide.replace(readButton, unreadBtn);
+
+      var readEvent = new ChapterReadStatusChangeEvent(readButton,true, true);
+      ComponentUtil.fireEvent(rightSide, readEvent);
+    });
+
+    return readButton;
+  }
+
+  private static Button getUnreadButton(Chapter chapter, MangaService mangaService, Div rightSide) {
+    Button unreadButton = new Button(VaadinIcon.EYE_SLASH.create());
+    unreadButton.addClickListener(e -> {
+      mangaService.setChapterUnread(chapter.getMangaId(), chapter.getIndex());
+      Button readBtn = getReadButton(chapter, mangaService, rightSide);
+      rightSide.replace(unreadButton, readBtn);
+
+      var readEvent = new ChapterReadStatusChangeEvent(unreadButton,true, false);
+      ComponentUtil.fireEvent(rightSide, readEvent);
+    });
+
+    return unreadButton;
+  }
+
+  private static void addReadStatus(HorizontalLayout container) {
+    container.addClassName("chapter-list-box-item-read");
+  }
+
+  private static void removeReadStatus(HorizontalLayout container) {
+    container.removeClassName("chapter-list-box-item-read");
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/event/ChapterReadStatusChangeEvent.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/event/ChapterReadStatusChangeEvent.java
@@ -4,7 +4,8 @@ import com.vaadin.flow.component.Component;
 import lombok.Getter;
 
 @Getter
-public class ChapterReadStatusChangeEvent extends com.vaadin.flow.component.ComponentEvent<Component> {
+public class ChapterReadStatusChangeEvent
+    extends com.vaadin.flow.component.ComponentEvent<Component> {
 
   private final boolean read;
 
@@ -12,9 +13,9 @@ public class ChapterReadStatusChangeEvent extends com.vaadin.flow.component.Comp
    * Creates a new event using the given source and indicator whether the event originated from the
    * client side or the server side.
    *
-   * @param source     the source component
-   * @param fromClient <code>true</code> if the event originated from the client
-   *                   side, <code>false</code> otherwise
+   * @param source the source component
+   * @param fromClient <code>true</code> if the event originated from the client side, <code>false
+   *     </code> otherwise
    */
   public ChapterReadStatusChangeEvent(Component source, boolean fromClient, boolean read) {
     super(source, fromClient);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/event/ChapterReadStatusChangeEvent.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/event/ChapterReadStatusChangeEvent.java
@@ -1,0 +1,23 @@
+package online.hatsunemiku.tachideskvaadinui.component.listbox.chapter.event;
+
+import com.vaadin.flow.component.Component;
+import lombok.Getter;
+
+@Getter
+public class ChapterReadStatusChangeEvent extends com.vaadin.flow.component.ComponentEvent<Component> {
+
+  private final boolean read;
+
+  /**
+   * Creates a new event using the given source and indicator whether the event originated from the
+   * client side or the server side.
+   *
+   * @param source     the source component
+   * @param fromClient <code>true</code> if the event originated from the client
+   *                   side, <code>false</code> otherwise
+   */
+  public ChapterReadStatusChangeEvent(Component source, boolean fromClient, boolean read) {
+    super(source, fromClient);
+    this.read = read;
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -1,7 +1,9 @@
 package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
+@Getter
 public class Chapter {
 
   @JsonProperty("pageCount")
@@ -55,73 +57,6 @@ public class Chapter {
   @JsonProperty("id")
   private int id;
 
-  public int getPageCount() {
-    return pageCount;
-  }
-
-  public boolean isRead() {
-    return read;
-  }
-
-  public int getMangaId() {
-    return mangaId;
-  }
-
-  public Object getScanlator() {
-    return scanlator;
-  }
-
-  public boolean isBookmarked() {
-    return bookmarked;
-  }
-
-  public int getChapterCount() {
-    return chapterCount;
-  }
-
-  public int getIndex() {
-    return index;
-  }
-
-  public int getFetchedAt() {
-    return fetchedAt;
-  }
-
-  public int getChapterNumber() {
-    return chapterNumber;
-  }
-
-  public boolean isDownloaded() {
-    return downloaded;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public int getLastReadAt() {
-    return lastReadAt;
-  }
-
-  public long getUploadDate() {
-    return uploadDate;
-  }
-
-  public int getLastPageRead() {
-    return lastPageRead;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getRealUrl() {
-    return realUrl;
-  }
-
-  public int getId() {
-    return id;
-  }
 
   @Override
   public String toString() {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -57,7 +57,6 @@ public class Chapter {
   @JsonProperty("id")
   private int id;
 
-
   @Override
   public String toString() {
     return name;

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
 import online.hatsunemiku.tachideskvaadinui.services.client.MangaClient;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -21,41 +22,31 @@ public class MangaService {
   }
 
   public void addMangaToLibrary(long mangaId) {
-    Settings settings = settingsService.getSettings();
-
-    URI baseUrl = URI.create(settings.getUrl());
+    URI baseUrl = getBaseUrl();
 
     mangaClient.addMangaToLibrary(baseUrl, mangaId);
   }
 
   public void removeMangaFromLibrary(long mangaId) {
-    Settings settings = settingsService.getSettings();
-
-    URI baseUrl = URI.create(settings.getUrl());
+    URI baseUrl = getBaseUrl();
 
     mangaClient.removeMangaFromLibrary(baseUrl, mangaId);
   }
 
   public List<Chapter> getChapterList(long mangaId) {
-    Settings settings = settingsService.getSettings();
-
-    URI baseUrl = URI.create(settings.getUrl());
+    URI baseUrl = getBaseUrl();
 
     return mangaClient.getChapterList(baseUrl, mangaId);
   }
 
   public Chapter getChapter(long mangaId, int chapterIndex) {
-    Settings settings = settingsService.getSettings();
-
-    URI baseUrl = URI.create(settings.getUrl());
+    URI baseUrl = getBaseUrl();
 
     return mangaClient.getChapter(baseUrl, mangaId, chapterIndex);
   }
 
   public boolean setChapterRead(long mangaId, int chapterIndex) {
-    Settings settings = settingsService.getSettings();
-
-    URI baseUrl = URI.create(settings.getUrl());
+    URI baseUrl = getBaseUrl();
 
     try {
       mangaClient.modifyReadStatus(baseUrl, mangaId, chapterIndex, true);
@@ -63,5 +54,23 @@ public class MangaService {
     } catch (Exception e) {
       return false;
     }
+  }
+
+  public boolean setChapterUnread(long mangaId, int chapterIndex) {
+    URI baseUrl = getBaseUrl();
+
+    try {
+      mangaClient.modifyReadStatus(baseUrl, mangaId, chapterIndex, false);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  @NotNull
+  private URI getBaseUrl() {
+    Settings settings = settingsService.getSettings();
+
+    return URI.create(settings.getUrl());
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -84,7 +84,7 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     imageContainer.addClassName("manga-image-container");
     imageContainer.add(image);
 
-    ListBox<Chapter> chapters = getChapters(mangaId);
+    ListBox<Chapter> chapters = getChapters(mangaId, mangaService);
 
     Div buttons = getButtons(manga);
 
@@ -152,10 +152,10 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     return manga;
   }
 
-  private ListBox<Chapter> getChapters(long mangaId) {
+  private ListBox<Chapter> getChapters(long mangaId, MangaService mangaService) {
 
     List<Chapter> chapter = mangaService.getChapterList(mangaId);
 
-    return new ChapterListBox(chapter);
+    return new ChapterListBox(chapter, mangaService);
   }
 }


### PR DESCRIPTION
Updated the ChapterRenderer and ChapterListBox to support changing the read/unread status of manga chapters. Now users can mark chapters as read or unread directly from the list, improving user interaction and experience. A new event 'ChapterReadStatusChangeEvent' has been added to fire when the read status of a chapter changes. The MangaService has been updated with methods to change the read status in the backend.

Note: You will only get redirected to a new chapter if you press on the actual blue part of the list item, as otherwise you wouldn't be able to interact with the buttons

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>