### PR TITLE
Add resume reading feature

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Manga.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Manga.java
@@ -86,5 +86,4 @@ public class Manga {
 
   @JsonProperty("status")
   private String status;
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Manga.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Manga.java
@@ -2,8 +2,10 @@ package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import lombok.Getter;
 import lombok.Setter;
 
+@Getter
 public class Manga {
 
   @JsonProperty("sourceId")
@@ -74,7 +76,7 @@ public class Manga {
   private int chaptersAge;
 
   @JsonProperty("lastChapterRead")
-  private Object lastChapterRead;
+  private Chapter lastChapterRead;
 
   @JsonProperty("downloadCount")
   private int downloadCount;
@@ -85,107 +87,4 @@ public class Manga {
   @JsonProperty("status")
   private String status;
 
-  public String getSourceId() {
-    return sourceId;
-  }
-
-  public String getArtist() {
-    return artist;
-  }
-
-  public int getChaptersLastFetchedAt() {
-    return chaptersLastFetchedAt;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public int getUnreadCount() {
-    return unreadCount;
-  }
-
-  public Object getSource() {
-    return source;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public boolean isFreshData() {
-    return freshData;
-  }
-
-  public int getThumbnailUrlLastFetched() {
-    return thumbnailUrlLastFetched;
-  }
-
-  public int getInLibraryAt() {
-    return inLibraryAt;
-  }
-
-  public List<String> getGenre() {
-    return genre;
-  }
-
-  public String getRealUrl() {
-    return realUrl;
-  }
-
-  public boolean isInitialized() {
-    return initialized;
-  }
-
-  public int getId() {
-    return id;
-  }
-
-  public String getThumbnailUrl() {
-    return thumbnailUrl;
-  }
-
-  public int getLastFetchedAt() {
-    return lastFetchedAt;
-  }
-
-  public boolean isInLibrary() {
-    return inLibrary;
-  }
-
-  public String getAuthor() {
-    return author;
-  }
-
-  public int getChapterCount() {
-    return chapterCount;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public String getUpdateStrategy() {
-    return updateStrategy;
-  }
-
-  public int getChaptersAge() {
-    return chaptersAge;
-  }
-
-  public Object getLastChapterRead() {
-    return lastChapterRead;
-  }
-
-  public int getDownloadCount() {
-    return downloadCount;
-  }
-
-  public int getAge() {
-    return age;
-  }
-
-  public String getStatus() {
-    return status;
-  }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import online.hatsunemiku.tachideskvaadinui.services.client.MangaClient;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,6 +66,18 @@ public class MangaService {
     } catch (Exception e) {
       return false;
     }
+  }
+
+  /**
+   * Retrieves the full information of a manga specified by its ID.
+   *
+   * @param mangaId the ID of the manga to retrieve
+   * @return a Manga object containing the full data of the manga
+   */
+  public Manga getMangaFull(long mangaId) {
+    URI baseUrl = getBaseUrl();
+
+    return mangaClient.getMangaFull(baseUrl, mangaId);
   }
 
   @NotNull

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
@@ -4,6 +4,7 @@ import feign.Headers;
 import java.net.URI;
 import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -38,4 +39,14 @@ public interface MangaClient {
       @PathVariable long mangaId,
       @PathVariable int chapterIndex,
       @RequestPart("read") boolean read);
+
+  /**
+   * Retrieves the full details of a manga based on the given manga ID.
+   *
+   * @param baseUrl  The base URL of the API.
+   * @param mangaId  The ID of the manga to retrieve.
+   * @return A Manga object representing the full data of the manga.
+   */
+  @GetMapping("/api/v1/manga/{mangaId}/full")
+  Manga getMangaFull(URI baseUrl, @PathVariable long mangaId);
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
@@ -43,8 +43,8 @@ public interface MangaClient {
   /**
    * Retrieves the full details of a manga based on the given manga ID.
    *
-   * @param baseUrl  The base URL of the API.
-   * @param mangaId  The ID of the manga to retrieve.
+   * @param baseUrl The base URL of the API.
+   * @param mangaId The ID of the manga to retrieve.
    * @return A Manga object representing the full data of the manga.
    */
   @GetMapping("/api/v1/manga/{mangaId}/full")

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/RouteUtils.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/RouteUtils.java
@@ -9,7 +9,6 @@ import online.hatsunemiku.tachideskvaadinui.view.ReadingView;
 @UtilityClass
 public class RouteUtils {
 
-
   /**
    * Method to route to the reading view.
    *

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/RouteUtils.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/RouteUtils.java
@@ -1,0 +1,32 @@
+package online.hatsunemiku.tachideskvaadinui.utils;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.RouteParam;
+import com.vaadin.flow.router.RouteParameters;
+import lombok.experimental.UtilityClass;
+import online.hatsunemiku.tachideskvaadinui.view.ReadingView;
+
+@UtilityClass
+public class RouteUtils {
+
+
+  /**
+   * Method to route to the reading view.
+   *
+   * @param ui The UI object to navigate with.
+   * @param mangaId The ID of the manga.
+   * @param chapterIndex The index of the chapter.
+   */
+  public void routeToReadingView(UI ui, long mangaId, long chapterIndex) {
+
+    String mangaIdString = String.valueOf(mangaId);
+    String chapterIndexString = String.valueOf(chapterIndex);
+
+    RouteParam mangaIdParam = new RouteParam("mangaId", mangaIdString);
+    RouteParam chapterIndexParam = new RouteParam("chapterIndex", chapterIndexString);
+
+    RouteParameters params = new RouteParameters(mangaIdParam, chapterIndexParam);
+
+    ui.navigate(ReadingView.class, params);
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -1,17 +1,21 @@
 package online.hatsunemiku.tachideskvaadinui.view;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.listbox.ListBox;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoIcon;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import online.hatsunemiku.tachideskvaadinui.component.dialog.tracking.TrackingDialog;
@@ -22,6 +26,7 @@ import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import online.hatsunemiku.tachideskvaadinui.services.AniListAPIService;
 import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
+import online.hatsunemiku.tachideskvaadinui.utils.RouteUtils;
 import online.hatsunemiku.tachideskvaadinui.view.layout.StandardLayout;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.web.client.RestTemplate;
@@ -63,7 +68,7 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
 
     Manga manga;
     try {
-      manga = getManga(settings, id);
+      manga = mangaService.getMangaFull(mangaId);
     } catch (Exception e) {
       event.rerouteTo(ServerStartView.class);
       return;
@@ -84,19 +89,21 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     imageContainer.addClassName("manga-image-container");
     imageContainer.add(image);
 
-    ListBox<Chapter> chapters = getChapters(mangaId, mangaService);
+    List<Chapter> chapters = mangaService.getChapterList(mangaId);
 
-    Div buttons = getButtons(manga);
+    ListBox<Chapter> chapterListBox = new ChapterListBox(chapters, mangaService);
+
+    Div buttons = getButtons(manga, chapters);
 
     H1 mangaTitle = new H1(manga.getTitle());
     mangaTitle.addClassName("manga-title");
 
-    container.add(mangaTitle, imageContainer, buttons, chapters);
+    container.add(mangaTitle, imageContainer, buttons, chapterListBox);
     setContent(container);
   }
 
   @NotNull
-  private Div getButtons(Manga manga) {
+  private Div getButtons(Manga manga, List<Chapter> chapters) {
     Div buttons = new Div();
     buttons.addClassName("manga-buttons");
 
@@ -112,8 +119,57 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
           dialog.open();
         });
 
-    buttons.add(libraryBtn, trackBtn);
+    Button resumeBtn = getResumeButton(manga, chapters);
+
+    buttons.add(libraryBtn, resumeBtn, trackBtn);
     return buttons;
+  }
+
+  /**
+   * Creates and retrieves the resume button for a manga, which allows the user to resume reading from the last chapter
+   * they left off.
+   *
+   * @param manga    The manga object for which to retrieve the resume button.
+   * @param chapters The list of chapters available for the manga.
+   * @return The resume button with the appropriate click listener.
+   */
+  @NotNull
+  private Button getResumeButton(Manga manga, List<Chapter> chapters) {
+    Button resumeBtn = new Button("Resume", LumoIcon.PLAY.create());
+    resumeBtn.addClassName("manga-btn");
+    resumeBtn.addClickListener(e -> {
+
+      if (chapters.isEmpty()) {
+        return;
+      }
+
+      Chapter nextChapter;
+
+      var lastChapter = manga.getLastChapterRead();
+      if (lastChapter == null) {
+        nextChapter = chapters.get(chapters.size() - 1);
+      } else {
+        // 1 based index
+        int index = lastChapter.getIndex();
+
+        if (index == chapters.size()) {
+          Notification notification = new Notification("No more chapters available", 3000);
+          notification.addThemeVariants(NotificationVariant.LUMO_PRIMARY);
+          notification.setPosition(Notification.Position.MIDDLE);
+          notification.open();
+          return;
+        }
+
+        Collections.reverse(chapters);
+
+        nextChapter = chapters.get(index);
+      }
+
+      UI ui = UI.getCurrent();
+
+      RouteUtils.routeToReadingView(ui, manga.getId(), nextChapter.getIndex());
+    });
+    return resumeBtn;
   }
 
   @NotNull
@@ -140,22 +196,4 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     return libraryBtn;
   }
 
-  private Manga getManga(Settings settings, String id) {
-    String mangaEndpoint = settings.getUrl() + "/api/v1/manga/" + id;
-
-    Manga manga = client.getForObject(mangaEndpoint, Manga.class);
-
-    if (manga == null) {
-      throw new NotFoundException("Manga not found");
-    }
-
-    return manga;
-  }
-
-  private ListBox<Chapter> getChapters(long mangaId, MangaService mangaService) {
-
-    List<Chapter> chapter = mangaService.getChapterList(mangaId);
-
-    return new ChapterListBox(chapter, mangaService);
-  }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -29,24 +29,20 @@ import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
 import online.hatsunemiku.tachideskvaadinui.utils.RouteUtils;
 import online.hatsunemiku.tachideskvaadinui.view.layout.StandardLayout;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.web.client.RestTemplate;
 
 @Route("manga/:id(\\d+)")
 @CssImport("./css/manga.css")
 public class MangaView extends StandardLayout implements BeforeEnterObserver {
 
-  private final RestTemplate client;
   private final MangaService mangaService;
   private final SettingsService settingsService;
   private final AniListAPIService aniListAPIService;
 
   public MangaView(
-      RestTemplate client,
       MangaService mangaService,
       SettingsService settingsService,
       AniListAPIService aniListAPIService) {
     super("Manga");
-    this.client = client;
     this.mangaService = mangaService;
     this.settingsService = settingsService;
     this.aniListAPIService = aniListAPIService;

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -122,10 +122,10 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
   }
 
   /**
-   * Creates and retrieves the resume button for a manga, which allows the user to resume reading from the last chapter
-   * they left off.
+   * Creates and retrieves the resume button for a manga, which allows the user to resume reading
+   * from the last chapter they left off.
    *
-   * @param manga    The manga object for which to retrieve the resume button.
+   * @param manga The manga object for which to retrieve the resume button.
    * @param chapters The list of chapters available for the manga.
    * @return The resume button with the appropriate click listener.
    */
@@ -133,38 +133,38 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
   private Button getResumeButton(Manga manga, List<Chapter> chapters) {
     Button resumeBtn = new Button("Resume", LumoIcon.PLAY.create());
     resumeBtn.addClassName("manga-btn");
-    resumeBtn.addClickListener(e -> {
+    resumeBtn.addClickListener(
+        e -> {
+          if (chapters.isEmpty()) {
+            return;
+          }
 
-      if (chapters.isEmpty()) {
-        return;
-      }
+          Chapter nextChapter;
 
-      Chapter nextChapter;
+          var lastChapter = manga.getLastChapterRead();
+          if (lastChapter == null) {
+            nextChapter = chapters.get(chapters.size() - 1);
+          } else {
+            // 1 based index
+            int index = lastChapter.getIndex();
 
-      var lastChapter = manga.getLastChapterRead();
-      if (lastChapter == null) {
-        nextChapter = chapters.get(chapters.size() - 1);
-      } else {
-        // 1 based index
-        int index = lastChapter.getIndex();
+            if (index == chapters.size()) {
+              Notification notification = new Notification("No more chapters available", 3000);
+              notification.addThemeVariants(NotificationVariant.LUMO_PRIMARY);
+              notification.setPosition(Notification.Position.MIDDLE);
+              notification.open();
+              return;
+            }
 
-        if (index == chapters.size()) {
-          Notification notification = new Notification("No more chapters available", 3000);
-          notification.addThemeVariants(NotificationVariant.LUMO_PRIMARY);
-          notification.setPosition(Notification.Position.MIDDLE);
-          notification.open();
-          return;
-        }
+            Collections.reverse(chapters);
 
-        Collections.reverse(chapters);
+            nextChapter = chapters.get(index);
+          }
 
-        nextChapter = chapters.get(index);
-      }
+          UI ui = UI.getCurrent();
 
-      UI ui = UI.getCurrent();
-
-      RouteUtils.routeToReadingView(ui, manga.getId(), nextChapter.getIndex());
-    });
+          RouteUtils.routeToReadingView(ui, manga.getId(), nextChapter.getIndex());
+        });
     return resumeBtn;
   }
 
@@ -191,5 +191,4 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     }
     return libraryBtn;
   }
-
 }


### PR DESCRIPTION
This commit adds a 'Resume Reading' button to the Manga view, this feature enables the user to continue from the last chapter they left off. Additionally, the Manga class has been refactored, the getters were removed, and the Lombok   'getter' annotation is applied to the class to handle this. Class RouteUtils has been added to handle routing to the reading view. The changes also include refactoring services' classes and methods in relation to needed features for the Resume Feature.


<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>