### PR TITLE
Improve MangaReader equality check and Chapter class

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/reader/MangaReader.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/reader/MangaReader.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.RouteParam;
 import com.vaadin.flow.router.RouteParameters;
 import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
@@ -113,6 +114,10 @@ public class MangaReader extends Div {
       chapterComboBox.addValueChangeListener(
           e -> {
             if (!e.isFromClient()) {
+              return;
+            }
+
+            if (Objects.equals(e.getOldValue(), e.getValue())) {
               return;
             }
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -63,6 +63,4 @@ public class Chapter {
   public String toString() {
     return name;
   }
-
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -1,9 +1,11 @@
 package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 public class Chapter {
 
   @JsonProperty("pageCount")
@@ -61,4 +63,6 @@ public class Chapter {
   public String toString() {
     return name;
   }
+
+
 }


### PR DESCRIPTION
Added an equality check in MangaReader to prevent unnecessary mutations and updates when the old and new values are the same. This is achieved using the Objects.equals() method. This check adds an extra layer of protection against possible redundant operations. Also, an "EqualsAndHashCode" annotation is added to the Chapter class to handle potential equality checks between Chapter objects, as before the equality check didn't work correctly

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>