### PR TITLE
Add drag and drop functionality for MangaCards

### DIFF
--- a/frontend/css/card.css
+++ b/frontend/css/card.css
@@ -33,9 +33,9 @@ img {
   position: absolute;
   bottom: 0;
   background-image: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.5),
-    rgba(0, 0, 0, 0.7)
+      to bottom,
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0.7)
   );
   color: #fff;
   height: 10%;
@@ -48,4 +48,13 @@ img {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   overflow: hidden;
+}
+
+.card-img {
+  user-drag: none;
+  -webkit-user-drag: none;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }

--- a/frontend/css/components/tab/category-tab.css
+++ b/frontend/css/components/tab/category-tab.css
@@ -1,0 +1,14 @@
+.category-tab.drop-target {
+  border: 1px dashed var(--miku-main-color);
+  background-color: var(--miku-main-color-50);
+  border-radius: 0.5rem;
+  transition: all 0.5s ease-in-out;
+}
+
+.category-tab {
+  border: 1px dashed transparent;
+  background-color: transparent;
+  border-radius: 0.5rem;
+  transition: all 0.5s ease-in-out;
+  margin-left: 0.5rem;
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/Card.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/Card.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class Card extends Div {
 
   private final Paragraph textComponent;
+
   public Card(String title, String imageUrl) {
     setClassName("card");
     addClassName("shadow-m");
@@ -25,5 +26,4 @@ public class Card extends Div {
 
     this.textComponent = p;
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/Card.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/Card.java
@@ -4,29 +4,26 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Paragraph;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.Getter;
 
+@Getter
 @CssImport("css/card.css")
 public class Card extends Div {
 
-  private static final Logger logger = LoggerFactory.getLogger(Card.class);
-
+  private final Paragraph textComponent;
   public Card(String title, String imageUrl) {
     setClassName("card");
     addClassName("shadow-m");
     addClassName("border");
 
     Image img = new Image(imageUrl, "Thumbnail");
+    img.addClassName("card-img");
 
     Paragraph p = new Paragraph(title);
     p.addClassName("card-title");
-
     add(img, p);
 
-    addClickListener(e -> logger.info("Clicked on card"));
-
-
+    this.textComponent = p;
   }
 
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/DraggableMangaCard.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/DraggableMangaCard.java
@@ -1,0 +1,63 @@
+package online.hatsunemiku.tachideskvaadinui.component.card;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dnd.DragSource;
+import com.vaadin.flow.component.dnd.EffectAllowed;
+import com.vaadin.flow.component.html.Div;
+import lombok.extern.slf4j.Slf4j;
+import online.hatsunemiku.tachideskvaadinui.component.card.data.MangaCategoryDragData;
+import online.hatsunemiku.tachideskvaadinui.component.card.event.MangaCategoryUpdateEvent;
+import online.hatsunemiku.tachideskvaadinui.component.tab.event.CategoryTabHighlightEvent;
+import online.hatsunemiku.tachideskvaadinui.data.Settings;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
+
+@Slf4j
+public class DraggableMangaCard extends MangaCard implements DragSource<Card> {
+
+  private final long mangaId;
+  private Category category;
+
+  public DraggableMangaCard(Settings settings, Manga manga, Category category) {
+    super(settings, manga);
+    this.mangaId = manga.getId();
+    this.category = category;
+
+    addDragStartListener(e -> {
+      MangaCategoryDragData dragData = new MangaCategoryDragData(manga, this.category);
+      e.setDragData(dragData);
+
+      var event = new CategoryTabHighlightEvent(this, true, true);
+
+      ComponentUtil.fireEvent(UI.getCurrent(), event);
+    });
+
+    addDragEndListener(e -> {
+      var event = new CategoryTabHighlightEvent(this, true, false);
+
+      ComponentUtil.fireEvent(UI.getCurrent(), event);
+    });
+
+    UI currentUI = UI.getCurrent();
+
+    ComponentUtil.addListener(currentUI, MangaCategoryUpdateEvent.class, e -> {
+      if (this.mangaId == e.getMangaId()) {
+        this.category = e.getNewCategory();
+        removeFromParent();
+
+        var tab = e.getSource();
+        Div grid = tab.getGrid();
+
+        if (grid == null) {
+          getUI().ifPresent(ui -> ui.getPage().reload());
+        } else {
+          grid.add(this);
+        }
+      }
+    });
+
+    setEffectAllowed(EffectAllowed.MOVE);
+    setDraggable(true);
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/DraggableMangaCard.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/DraggableMangaCard.java
@@ -24,38 +24,43 @@ public class DraggableMangaCard extends MangaCard implements DragSource<Card> {
     this.mangaId = manga.getId();
     this.category = category;
 
-    addDragStartListener(e -> {
-      MangaCategoryDragData dragData = new MangaCategoryDragData(manga, this.category);
-      e.setDragData(dragData);
+    addDragStartListener(
+        e -> {
+          MangaCategoryDragData dragData = new MangaCategoryDragData(manga, this.category);
+          e.setDragData(dragData);
 
-      var event = new CategoryTabHighlightEvent(this, true, true);
+          var event = new CategoryTabHighlightEvent(this, true, true);
 
-      ComponentUtil.fireEvent(UI.getCurrent(), event);
-    });
+          ComponentUtil.fireEvent(UI.getCurrent(), event);
+        });
 
-    addDragEndListener(e -> {
-      var event = new CategoryTabHighlightEvent(this, true, false);
+    addDragEndListener(
+        e -> {
+          var event = new CategoryTabHighlightEvent(this, true, false);
 
-      ComponentUtil.fireEvent(UI.getCurrent(), event);
-    });
+          ComponentUtil.fireEvent(UI.getCurrent(), event);
+        });
 
     UI currentUI = UI.getCurrent();
 
-    ComponentUtil.addListener(currentUI, MangaCategoryUpdateEvent.class, e -> {
-      if (this.mangaId == e.getMangaId()) {
-        this.category = e.getNewCategory();
-        removeFromParent();
+    ComponentUtil.addListener(
+        currentUI,
+        MangaCategoryUpdateEvent.class,
+        e -> {
+          if (this.mangaId == e.getMangaId()) {
+            this.category = e.getNewCategory();
+            removeFromParent();
 
-        var tab = e.getSource();
-        Div grid = tab.getGrid();
+            var tab = e.getSource();
+            Div grid = tab.getGrid();
 
-        if (grid == null) {
-          getUI().ifPresent(ui -> ui.getPage().reload());
-        } else {
-          grid.add(this);
-        }
-      }
-    });
+            if (grid == null) {
+              getUI().ifPresent(ui -> ui.getPage().reload());
+            } else {
+              grid.add(this);
+            }
+          }
+        });
 
     setEffectAllowed(EffectAllowed.MOVE);
     setDraggable(true);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/MangaCard.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/MangaCard.java
@@ -1,10 +1,12 @@
 package online.hatsunemiku.tachideskvaadinui.component.card;
 
 import com.vaadin.flow.router.RouteParameters;
-import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
+import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import online.hatsunemiku.tachideskvaadinui.view.MangaView;
 
+@Slf4j
 public class MangaCard extends Card {
 
   public MangaCard(Settings settings, Manga manga) {
@@ -15,5 +17,4 @@ public class MangaCard extends Card {
       getUI().ifPresent(ui -> ui.navigate(MangaView.class, params));
     });
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/MangaCard.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/MangaCard.java
@@ -11,10 +11,11 @@ public class MangaCard extends Card {
 
   public MangaCard(Settings settings, Manga manga) {
     super(manga.getTitle(), settings.getUrl() + manga.getThumbnailUrl());
-    addClickListener(e -> {
-      RouteParameters params = new RouteParameters("id", String.valueOf(manga.getId()));
+    addClickListener(
+        e -> {
+          RouteParameters params = new RouteParameters("id", String.valueOf(manga.getId()));
 
-      getUI().ifPresent(ui -> ui.navigate(MangaView.class, params));
-    });
+          getUI().ifPresent(ui -> ui.navigate(MangaView.class, params));
+        });
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/data/MangaCategoryDragData.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/data/MangaCategoryDragData.java
@@ -3,6 +3,4 @@ package online.hatsunemiku.tachideskvaadinui.component.card.data;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 
-public record MangaCategoryDragData(Manga manga, Category category) {
-
-}
+public record MangaCategoryDragData(Manga manga, Category category) {}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/data/MangaCategoryDragData.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/data/MangaCategoryDragData.java
@@ -1,0 +1,8 @@
+package online.hatsunemiku.tachideskvaadinui.component.card.data;
+
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
+
+public record MangaCategoryDragData(Manga manga, Category category) {
+
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/event/MangaCategoryUpdateEvent.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/event/MangaCategoryUpdateEvent.java
@@ -15,11 +15,12 @@ public class MangaCategoryUpdateEvent extends ComponentEvent<CategoryTab> {
    * Creates a new event using the given source and indicator whether the event originated from the
    * client side or the server side.
    *
-   * @param source     the source component
-   * @param fromClient <code>true</code> if the event originated from the client
-   *                   side, <code>false</code> otherwise
+   * @param source the source component
+   * @param fromClient <code>true</code> if the event originated from the client side, <code>false
+   *     </code> otherwise
    */
-  public MangaCategoryUpdateEvent(CategoryTab source, boolean fromClient, long mangaId, Category newCategory) {
+  public MangaCategoryUpdateEvent(
+      CategoryTab source, boolean fromClient, long mangaId, Category newCategory) {
     super(source, fromClient);
     this.newCategory = newCategory;
     this.mangaId = mangaId;

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/event/MangaCategoryUpdateEvent.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/event/MangaCategoryUpdateEvent.java
@@ -1,0 +1,27 @@
+package online.hatsunemiku.tachideskvaadinui.component.card.event;
+
+import com.vaadin.flow.component.ComponentEvent;
+import lombok.Getter;
+import online.hatsunemiku.tachideskvaadinui.component.tab.CategoryTab;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
+
+@Getter
+public class MangaCategoryUpdateEvent extends ComponentEvent<CategoryTab> {
+
+  private final long mangaId;
+  private final Category newCategory;
+
+  /**
+   * Creates a new event using the given source and indicator whether the event originated from the
+   * client side or the server side.
+   *
+   * @param source     the source component
+   * @param fromClient <code>true</code> if the event originated from the client
+   *                   side, <code>false</code> otherwise
+   */
+  public MangaCategoryUpdateEvent(CategoryTab source, boolean fromClient, long mangaId, Category newCategory) {
+    super(source, fromClient);
+    this.newCategory = newCategory;
+    this.mangaId = mangaId;
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/CategoryTab.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/CategoryTab.java
@@ -24,67 +24,70 @@ import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 @CssImport("./css/components/tab/category-tab.css")
 public class CategoryTab extends Tab implements DropTarget<Tab> {
 
-  @Setter
-  private Div grid;
+  @Setter private Div grid;
 
   public CategoryTab(Category category, MangaService mangaService) {
     super(category.getName());
 
     addClassName("category-tab");
 
-    addDropListener(e -> {
-      var dragData = e.getDragData();
+    addDropListener(
+        e -> {
+          var dragData = e.getDragData();
 
-      if (dragData.isEmpty()) {
-        return;
-      }
+          if (dragData.isEmpty()) {
+            return;
+          }
 
-      var obj = dragData.get();
+          var obj = dragData.get();
 
-      if (obj instanceof MangaCategoryDragData data) {
-        Manga manga = data.manga();
-        Category oldCategory = data.category();
+          if (obj instanceof MangaCategoryDragData data) {
+            Manga manga = data.manga();
+            Category oldCategory = data.category();
 
-        if (category.getId() == 0) {
-          Notification notification = new Notification("Cannot move to Default", 3000);
-          notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-          notification.open();
-          return;
-        }
+            if (category.getId() == 0) {
+              Notification notification = new Notification("Cannot move to Default", 3000);
+              notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+              notification.open();
+              return;
+            }
 
-        if (category.getId() == oldCategory.getId()) {
-          Notification notification = new Notification("Cannot move to same category", 3000);
-          notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-          notification.open();
-          return;
-        }
+            if (category.getId() == oldCategory.getId()) {
+              Notification notification = new Notification("Cannot move to same category", 3000);
+              notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+              notification.open();
+              return;
+            }
 
-        mangaService.moveMangaToCategory(manga.getId(), category.getId(), oldCategory.getId());
-        log.debug("Manga {} moved to category {}", manga.getTitle(), category.getName());
+            mangaService.moveMangaToCategory(manga.getId(), category.getId(), oldCategory.getId());
+            log.debug("Manga {} moved to category {}", manga.getTitle(), category.getName());
 
-        long mangaId = manga.getId();
+            long mangaId = manga.getId();
 
-        var updateEvent = new MangaCategoryUpdateEvent(this, true, mangaId, category);
-        var highlightEvent = new CategoryTabHighlightEvent(this, true, false);
+            var updateEvent = new MangaCategoryUpdateEvent(this, true, mangaId, category);
+            var highlightEvent = new CategoryTabHighlightEvent(this, true, false);
 
-        if (getUI().isEmpty()) {
-          return;
-        }
+            if (getUI().isEmpty()) {
+              return;
+            }
 
-        log.debug("Firing update event for manga {}", manga.getTitle());
+            log.debug("Firing update event for manga {}", manga.getTitle());
 
-        ComponentUtil.fireEvent(getUI().get(), updateEvent);
-        ComponentUtil.fireEvent(getUI().get(), highlightEvent);
-      }
-    });
+            ComponentUtil.fireEvent(getUI().get(), updateEvent);
+            ComponentUtil.fireEvent(getUI().get(), highlightEvent);
+          }
+        });
 
-    ComponentUtil.addListener(UI.getCurrent(), CategoryTabHighlightEvent.class, e -> {
-      if (e.isHighlight()) {
-        addClassName("drop-target");
-      } else {
-        removeClassName("drop-target");
-      }
-    });
+    ComponentUtil.addListener(
+        UI.getCurrent(),
+        CategoryTabHighlightEvent.class,
+        e -> {
+          if (e.isHighlight()) {
+            addClassName("drop-target");
+          } else {
+            removeClassName("drop-target");
+          }
+        });
 
     setDropEffect(DropEffect.MOVE);
     setActive(true);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/CategoryTab.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/CategoryTab.java
@@ -1,0 +1,92 @@
+package online.hatsunemiku.tachideskvaadinui.component.tab;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.dnd.DropEffect;
+import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.tabs.Tab;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import online.hatsunemiku.tachideskvaadinui.component.card.data.MangaCategoryDragData;
+import online.hatsunemiku.tachideskvaadinui.component.card.event.MangaCategoryUpdateEvent;
+import online.hatsunemiku.tachideskvaadinui.component.tab.event.CategoryTabHighlightEvent;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
+import online.hatsunemiku.tachideskvaadinui.services.MangaService;
+
+@Getter
+@Slf4j
+@CssImport("./css/components/tab/category-tab.css")
+public class CategoryTab extends Tab implements DropTarget<Tab> {
+
+  @Setter
+  private Div grid;
+
+  public CategoryTab(Category category, MangaService mangaService) {
+    super(category.getName());
+
+    addClassName("category-tab");
+
+    addDropListener(e -> {
+      var dragData = e.getDragData();
+
+      if (dragData.isEmpty()) {
+        return;
+      }
+
+      var obj = dragData.get();
+
+      if (obj instanceof MangaCategoryDragData data) {
+        Manga manga = data.manga();
+        Category oldCategory = data.category();
+
+        if (category.getId() == 0) {
+          Notification notification = new Notification("Cannot move to Default", 3000);
+          notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+          notification.open();
+          return;
+        }
+
+        if (category.getId() == oldCategory.getId()) {
+          Notification notification = new Notification("Cannot move to same category", 3000);
+          notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+          notification.open();
+          return;
+        }
+
+        mangaService.moveMangaToCategory(manga.getId(), category.getId(), oldCategory.getId());
+        log.debug("Manga {} moved to category {}", manga.getTitle(), category.getName());
+
+        long mangaId = manga.getId();
+
+        var updateEvent = new MangaCategoryUpdateEvent(this, true, mangaId, category);
+        var highlightEvent = new CategoryTabHighlightEvent(this, true, false);
+
+        if (getUI().isEmpty()) {
+          return;
+        }
+
+        log.debug("Firing update event for manga {}", manga.getTitle());
+
+        ComponentUtil.fireEvent(getUI().get(), updateEvent);
+        ComponentUtil.fireEvent(getUI().get(), highlightEvent);
+      }
+    });
+
+    ComponentUtil.addListener(UI.getCurrent(), CategoryTabHighlightEvent.class, e -> {
+      if (e.isHighlight()) {
+        addClassName("drop-target");
+      } else {
+        removeClassName("drop-target");
+      }
+    });
+
+    setDropEffect(DropEffect.MOVE);
+    setActive(true);
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/event/CategoryTabHighlightEvent.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/event/CategoryTabHighlightEvent.java
@@ -12,9 +12,9 @@ public class CategoryTabHighlightEvent extends ComponentEvent<Component> {
    * Creates a new event using the given source and indicator whether the event originated from the
    * client side or the server side.
    *
-   * @param source     the source component
-   * @param fromClient <code>true</code> if the event originated from the client
-   *                   side, <code>false</code> otherwise
+   * @param source the source component
+   * @param fromClient <code>true</code> if the event originated from the client side, <code>false
+   *     </code> otherwise
    */
   public CategoryTabHighlightEvent(Component source, boolean fromClient, boolean highlight) {
     super(source, fromClient);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/event/CategoryTabHighlightEvent.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/tab/event/CategoryTabHighlightEvent.java
@@ -1,0 +1,23 @@
+package online.hatsunemiku.tachideskvaadinui.component.tab.event;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import lombok.Getter;
+
+@Getter
+public class CategoryTabHighlightEvent extends ComponentEvent<Component> {
+  private final boolean highlight;
+
+  /**
+   * Creates a new event using the given source and indicator whether the event originated from the
+   * client side or the server side.
+   *
+   * @param source     the source component
+   * @param fromClient <code>true</code> if the event originated from the client
+   *                   side, <code>false</code> otherwise
+   */
+  public CategoryTabHighlightEvent(Component source, boolean fromClient, boolean highlight) {
+    super(source, fromClient);
+    this.highlight = highlight;
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -80,6 +80,41 @@ public class MangaService {
     return mangaClient.getMangaFull(baseUrl, mangaId);
   }
 
+  /**
+   * Adds a manga to a category.
+   *
+   * @param mangaId the ID of the manga to be added
+   * @param categoryId the ID of the category to add the manga to
+   */
+  public void addMangaToCategory(long mangaId, long categoryId) {
+    URI baseUrl = getBaseUrl();
+
+    mangaClient.addMangaToCategory(baseUrl, mangaId, categoryId);
+  }
+
+  /**
+   * Removes a manga from a category.
+   *
+   * @param mangaId the ID of the manga to be removed
+   * @param categoryId the ID of the category to remove the manga from
+   */
+  public void removeMangaFromCategory(long mangaId, long categoryId) {
+    URI baseUrl = getBaseUrl();
+
+    mangaClient.removeMangaFromCategory(baseUrl, mangaId, categoryId);
+  }
+
+  public void moveMangaToCategory(long mangaId, long newCategoryId, long oldCategoryId) {
+    addMangaToCategory(mangaId, newCategoryId);
+    removeMangaFromCategory(mangaId, oldCategoryId);
+  }
+
+  /**
+   * Retrieves the base URL for the manga service.
+   *
+   * @return the base URL for the manga service
+   * @throws NullPointerException if the URL is null
+   */
   @NotNull
   private URI getBaseUrl() {
     Settings settings = settingsService.getSettings();

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
@@ -49,4 +49,10 @@ public interface MangaClient {
    */
   @GetMapping("/api/v1/manga/{mangaId}/full")
   Manga getMangaFull(URI baseUrl, @PathVariable long mangaId);
+
+  @GetMapping("/api/v1/manga/{mangaId}/category/{categoryId}")
+  void addMangaToCategory(URI baseUrl, @PathVariable long mangaId, @PathVariable long categoryId);
+
+  @DeleteMapping("/api/v1/manga/{mangaId}/category/{categoryId}")
+  void removeMangaFromCategory(URI baseUrl, @PathVariable long mangaId, @PathVariable long categoryId);
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/MangaClient.java
@@ -54,5 +54,6 @@ public interface MangaClient {
   void addMangaToCategory(URI baseUrl, @PathVariable long mangaId, @PathVariable long categoryId);
 
   @DeleteMapping("/api/v1/manga/{mangaId}/category/{categoryId}")
-  void removeMangaFromCategory(URI baseUrl, @PathVariable long mangaId, @PathVariable long categoryId);
+  void removeMangaFromCategory(
+      URI baseUrl, @PathVariable long mangaId, @PathVariable long categoryId);
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -15,12 +15,15 @@ import com.vaadin.flow.component.tabs.TabSheetVariant;
 import com.vaadin.flow.router.Route;
 import java.util.ArrayList;
 import java.util.List;
+import online.hatsunemiku.tachideskvaadinui.component.card.DraggableMangaCard;
 import online.hatsunemiku.tachideskvaadinui.component.card.MangaCard;
 import online.hatsunemiku.tachideskvaadinui.component.dialog.category.CategoryDialog;
+import online.hatsunemiku.tachideskvaadinui.component.tab.CategoryTab;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import online.hatsunemiku.tachideskvaadinui.services.LibUpdateService;
+import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
 import online.hatsunemiku.tachideskvaadinui.utils.CategoryUtils;
 import online.hatsunemiku.tachideskvaadinui.view.layout.StandardLayout;
@@ -37,14 +40,15 @@ public class RootView extends StandardLayout {
   private final SettingsService settingsService;
   private TabSheet tabs;
   private final LibUpdateService libUpdateService;
+  private final MangaService mangaService;
 
-  public RootView(
-      RestTemplate client, SettingsService settingsService, LibUpdateService libUpdateService) {
+  public RootView(RestTemplate client, SettingsService settingsService, LibUpdateService libUpdateService, MangaService mangaService) {
     super("Library");
 
     this.client = client;
     this.settingsService = settingsService;
     this.libUpdateService = libUpdateService;
+    this.mangaService = mangaService;
 
     Settings settings = settingsService.getSettings();
 
@@ -135,9 +139,10 @@ public class RootView extends StandardLayout {
   }
 
   private void addCategoryTab(Settings settings, Category c) {
-    Tab tab = new Tab(c.getName());
+    CategoryTab tab = new CategoryTab(c, mangaService);
 
     Div grid = createMangaGrid(settings, c);
+    tab.setGrid(grid);
 
     if (c.getId() != 0) {
       Button deleteButton = createCategoryDeleteButton(c, tab);
@@ -174,13 +179,13 @@ public class RootView extends StandardLayout {
     Div grid = new Div();
     grid.addClassName("library-grid");
 
-    fillMangaGrid(settings, manga, grid);
+    fillMangaGrid(settings, manga, grid, c);
     return grid;
   }
 
-  private static void fillMangaGrid(Settings settings, List<Manga> manga, Div grid) {
+  private static void fillMangaGrid(Settings settings, List<Manga> manga, Div grid, Category c) {
     for (Manga m : manga) {
-      MangaCard card = new MangaCard(settings, m);
+      MangaCard card = new DraggableMangaCard(settings, m, c);
       grid.add(card);
     }
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -42,7 +42,11 @@ public class RootView extends StandardLayout {
   private final LibUpdateService libUpdateService;
   private final MangaService mangaService;
 
-  public RootView(RestTemplate client, SettingsService settingsService, LibUpdateService libUpdateService, MangaService mangaService) {
+  public RootView(
+      RestTemplate client,
+      SettingsService settingsService,
+      LibUpdateService libUpdateService,
+      MangaService mangaService) {
     super("Library");
 
     this.client = client;


### PR DESCRIPTION
This commit introduces the ability for users to drag and drop MangaCards into different categories. These changes enhance user interactivity and allow for better organization of manga reading lists. Multiple new classes have been added, including DraggableMangaCard and CategoryTab along with supporting events. This also includes some adjustments and additions to CSS for styling these new components. Actions to add, move and remove Manga from categories have also been included in MangaService.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>