### PR TITLE
Refactor manga fetching from categories to service layer

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/CategoryService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/CategoryService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import online.hatsunemiku.tachideskvaadinui.services.client.CategoryClient;
 import org.jetbrains.annotations.Contract;
 import org.springframework.stereotype.Service;
@@ -79,6 +80,17 @@ public class CategoryService {
       return categoryClient.getCategories(baseUrl);
     } catch (Exception e) {
       log.error("Failed to get categories", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  public List<Manga> getMangaFromCategory(int categoryId) {
+    URI baseUrl = URI.create(settingsService.getSettings().getUrl());
+
+    try {
+      return categoryClient.getMangaFromCategory(baseUrl, categoryId);
+    } catch (Exception e) {
+      log.error("Failed to get manga from category", e);
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/CategoryClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/CategoryClient.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Category;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,14 +14,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-/** Represents a client for interacting with the Category API Endpoint. */
+/**
+ * Represents a client for interacting with the Category API Endpoint.
+ */
 @FeignClient(name = "category-service", url = "http://localhost:8080")
 public interface CategoryClient {
 
   /**
    * Creates a new category.
    *
-   * @param baseUrl the base URL of the API
+   * @param baseUrl    the base URL of the API
    * @param formParams the form parameters for creating the category
    */
   @PostMapping(value = "/api/v1/category", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -30,7 +33,7 @@ public interface CategoryClient {
   /**
    * Deletes a category.
    *
-   * @param baseUrl the base URL of the API
+   * @param baseUrl    the base URL of the API
    * @param categoryId the ID of the category to delete
    */
   @DeleteMapping("/api/v1/category/{categoryId}")
@@ -44,4 +47,14 @@ public interface CategoryClient {
    */
   @GetMapping("/api/v1/category")
   List<Category> getCategories(URI baseUrl);
+
+  /**
+   * Retrieves manga from a specific category from the API.
+   *
+   * @param baseUrl    the base URL of the API
+   * @param categoryId the ID of the category to retrieve manga from
+   * @return a list of {@link Manga} objects representing the manga retrieved from the API
+   */
+  @GetMapping("/api/v1/category/{categoryId}")
+  List<Manga> getMangaFromCategory(URI baseUrl, @PathVariable int categoryId);
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/CategoryClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/CategoryClient.java
@@ -14,16 +14,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-/**
- * Represents a client for interacting with the Category API Endpoint.
- */
+/** Represents a client for interacting with the Category API Endpoint. */
 @FeignClient(name = "category-service", url = "http://localhost:8080")
 public interface CategoryClient {
 
   /**
    * Creates a new category.
    *
-   * @param baseUrl    the base URL of the API
+   * @param baseUrl the base URL of the API
    * @param formParams the form parameters for creating the category
    */
   @PostMapping(value = "/api/v1/category", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -33,7 +31,7 @@ public interface CategoryClient {
   /**
    * Deletes a category.
    *
-   * @param baseUrl    the base URL of the API
+   * @param baseUrl the base URL of the API
    * @param categoryId the ID of the category to delete
    */
   @DeleteMapping("/api/v1/category/{categoryId}")
@@ -51,7 +49,7 @@ public interface CategoryClient {
   /**
    * Retrieves manga from a specific category from the API.
    *
-   * @param baseUrl    the base URL of the API
+   * @param baseUrl the base URL of the API
    * @param categoryId the ID of the category to retrieve manga from
    * @return a list of {@link Manga} objects representing the manga retrieved from the API
    */

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -1,7 +1,5 @@
 package online.hatsunemiku.tachideskvaadinui.view;
 
-import static org.springframework.http.HttpMethod.GET;
-
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.CssImport;
@@ -13,7 +11,6 @@ import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.TabSheet;
 import com.vaadin.flow.component.tabs.TabSheetVariant;
 import com.vaadin.flow.router.Route;
-import java.util.ArrayList;
 import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.component.card.DraggableMangaCard;
 import online.hatsunemiku.tachideskvaadinui.component.card.MangaCard;
@@ -28,28 +25,23 @@ import online.hatsunemiku.tachideskvaadinui.services.MangaService;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
 import online.hatsunemiku.tachideskvaadinui.view.layout.StandardLayout;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.web.client.RestTemplate;
 
 @Route("/")
 @CssImport("css/root.css")
 public class RootView extends StandardLayout {
 
-  private final RestTemplate client;
   private TabSheet tabs;
   private final LibUpdateService libUpdateService;
   private final MangaService mangaService;
   private final CategoryService categoryService;
 
   public RootView(
-      RestTemplate client,
       SettingsService settingsService,
       LibUpdateService libUpdateService,
       MangaService mangaService,
       CategoryService categoryService) {
     super("Library");
 
-    this.client = client;
     this.libUpdateService = libUpdateService;
     this.categoryService = categoryService;
     this.mangaService = mangaService;
@@ -121,20 +113,6 @@ public class RootView extends StandardLayout {
     setContent(tabs);
   }
 
-  private List<Manga> getManga(Category category, Settings settings) {
-    String template = "%s/api/v1/category/%d";
-    String categoryMangaEndpoint = String.format(template, settings.getUrl(), category.getId());
-
-    ParameterizedTypeReference<List<Manga>> typeRef = new ParameterizedTypeReference<>() {};
-    List<Manga> mangaList = client.exchange(categoryMangaEndpoint, GET, null, typeRef).getBody();
-
-    if (mangaList == null) {
-      return new ArrayList<>();
-    }
-
-    return mangaList;
-  }
-
   private void addCategoryTabs(List<Category> categories, Settings settings) {
     for (Category c : categories) {
       addCategoryTab(settings, c);
@@ -143,6 +121,8 @@ public class RootView extends StandardLayout {
 
   private void addCategoryTab(Settings settings, Category c) {
     CategoryTab tab = new CategoryTab(c, mangaService);
+
+
 
     Div grid = createMangaGrid(settings, c);
     tab.setGrid(grid);
@@ -176,7 +156,14 @@ public class RootView extends StandardLayout {
 
   @NotNull
   private Div createMangaGrid(Settings settings, Category c) {
-    List<Manga> manga = getManga(c, settings);
+    List<Manga> manga;
+    try {
+      manga = categoryService.getMangaFromCategory(c.getId());
+    } catch (Exception e) {
+      UI ui = UI.getCurrent();
+      ui.access(() -> ui.navigate(ServerStartView.class));
+      return new Div();
+    }
 
     Div grid = new Div();
     grid.addClassName("library-grid");

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -122,8 +122,6 @@ public class RootView extends StandardLayout {
   private void addCategoryTab(Settings settings, Category c) {
     CategoryTab tab = new CategoryTab(c, mangaService);
 
-
-
     Div grid = createMangaGrid(settings, c);
     tab.setGrid(grid);
 


### PR DESCRIPTION
Introduced a new method 'getMangaFromCategory' in CategoryService for fetching manga from specific categories. This change centralizes and encapsulates the fetching logic, leading to cleaner structure and separation of concerns. Meanwhile, redundant code in RootView which previously implemented the fetching within the view have been removed, resulting in an optimized code flow.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>