### PR TITLE
Update serialization methods to include project directory path

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskMaintainer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskMaintainer.java
@@ -36,12 +36,9 @@ public class TachideskMaintainer {
   private final RestTemplate client;
   private final TachideskStarter starter;
   private static final File serverDir = new File("server");
-  @Getter
-  private final File projectDir = getProjectDirFile();
-  @Getter
-  private boolean updating = false;
-  @Getter
-  private double progress = 0;
+  @Getter private final File projectDir = getProjectDirFile();
+  @Getter private boolean updating = false;
+  @Getter private double progress = 0;
 
   public TachideskMaintainer(RestTemplate client, TachideskStarter starter) {
     this.client = client;
@@ -151,9 +148,8 @@ public class TachideskMaintainer {
       }
     }
 
-
     Path projectDir;
-    //check for linux
+    // check for linux
     if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
       projectDir = appdata.resolve(".TachideskVaadinUI");
     } else {
@@ -168,7 +164,8 @@ public class TachideskMaintainer {
   /**
    * Checks if the project directory exists and creates it if it does not.
    *
-   * @return {@code true} if the project directory exists or was successfully created, {@code false} otherwise.
+   * @return {@code true} if the project directory exists or was successfully created, {@code false}
+   *     otherwise.
    */
   private boolean checkProjectDir() {
     if (!projectDir.exists()) {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskMaintainer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskMaintainer.java
@@ -67,7 +67,7 @@ public class TachideskMaintainer {
 
     logger.info("Checking for updates...");
 
-    Meta oldServer = SerializationUtils.deseralizeMetadata();
+    Meta oldServer = SerializationUtils.deserializeMetadata(projectDir.toPath());
 
     logger.info("Current jar file: {}", oldServer.getJarName());
 
@@ -119,7 +119,7 @@ public class TachideskMaintainer {
     oldServer.setJarRevision(newServerMeta.getJarRevision());
     oldServer.setJarLocation(serverFile.getPath());
 
-    SerializationUtils.serializeMetadata(oldServer);
+    SerializationUtils.serializeMetadata(oldServer, projectDir.toPath());
 
     logger.info("Restarting server...");
     starter.startJar(projectDir);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -19,7 +19,7 @@ public class TachideskStarter {
 
   public void startJar(File projectDir) {
 
-    Meta meta = SerializationUtils.deseralizeMetadata();
+    Meta meta = SerializationUtils.deserializeMetadata(projectDir.toPath());
 
     String jarLocation = meta.getJarLocation();
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -56,5 +56,4 @@ public class TachideskStarter {
       serverProcess.destroyForcibly();
     }
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/SerializationUtils.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/SerializationUtils.java
@@ -3,9 +3,11 @@ package online.hatsunemiku.tachideskvaadinui.utils;
 import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import online.hatsunemiku.tachideskvaadinui.data.Meta;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,27 +15,41 @@ public class SerializationUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(SerializationUtils.class);
 
-  public static void serializeMetadata(Meta meta) {
+  /**
+   * Serializes the {@link Meta} object to a JSON file.
+   *
+   * @param meta       the {@link Meta} object to be serialized
+   * @param projectDir the directory where the JSON file will be created
+   * @throws RuntimeException if there was an error during serialization
+   */
+  public static void serializeMetadata(Meta meta, @NotNull Path projectDir) {
     ObjectMapper mapper = new ObjectMapper();
     try {
-      File metaFile = new File("meta.json");
-      mapper.writeValue(metaFile, meta);
+      Path metaPath = projectDir.resolve("meta.json");
+      mapper.writeValue(metaPath.toFile(), meta);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public static Meta deseralizeMetadata() {
+  /**
+   * Deserializes the {@link Meta} object from a JSON file.
+   *
+   * @param projectDir the directory where the JSON file is located
+   * @return the deserialized {@link Meta} object
+   * @throws RuntimeException if there was an error during deserialization
+   */
+  public static Meta deserializeMetadata(@NotNull Path projectDir) {
     ObjectMapper mapper = new ObjectMapper();
 
     try {
-      File metaFile = new File("meta.json");
+      Path metaPath = projectDir.resolve("meta.json");
 
-      if (!metaFile.exists()) {
+      if (!Files.exists(metaPath)) {
         return new Meta();
       }
 
-      return mapper.readValue(metaFile, Meta.class);
+      return mapper.readValue(metaPath.toFile(), Meta.class);
     } catch (StreamReadException e) {
       logger.error("Invalid content", e);
       throw new RuntimeException(e);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/SerializationUtils.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/utils/SerializationUtils.java
@@ -18,7 +18,7 @@ public class SerializationUtils {
   /**
    * Serializes the {@link Meta} object to a JSON file.
    *
-   * @param meta       the {@link Meta} object to be serialized
+   * @param meta the {@link Meta} object to be serialized
    * @param projectDir the directory where the JSON file will be created
    * @throws RuntimeException if there was an error during serialization
    */


### PR DESCRIPTION
Modified methods serializeMetadata and deserializeMetadata in SerializationUtils class to take project directory path as an argument. This was done to fix the issue where the meta.json file was not located correctly. Now, the serializeMetadata method saves the meta.json file to the given project directory, and deserializeMetadata reads the meta.json file from the provided project directory.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>