### PR TITLE
Add logging and enhance error handling in SettingsService

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SettingsService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SettingsService.java
@@ -25,8 +25,7 @@ public class SettingsService {
 
   private static final Logger logger = LoggerFactory.getLogger(SettingsService.class);
 
-  @Getter
-  private final Settings settings;
+  @Getter private final Settings settings;
 
   @Getter(AccessLevel.NONE)
   private final ObjectMapper mapper;


### PR DESCRIPTION
Improved error handling and logging in SettingsService.java to tackle potential NullPointerExceptions. Added a null check in the process of fetching settings from a file. If settings are not found or null, defaults are used. This resolves an issue where sometimes null would be written to the settings file, resulting in it always being null when read. This should now be stopped and null values should always be corrected when deserializing.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>