### PR TITLE
Fix condition check in manga chapter renderer

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -113,7 +113,7 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
     Button readButton = new Button(VaadinIcon.EYE.create());
     readButton.addClickListener(
         e -> {
-          if (mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex())) {
+          if (!mangaService.setChapterRead(chapter.getMangaId(), chapter.getIndex())) {
             log.error("Failed to set chapter read");
             Notification notification = new Notification("Failed to set chapter read", 5000);
             notification.setPosition(Notification.Position.MIDDLE);


### PR DESCRIPTION
The conditional check in the chapter read button in ChapterRenderer.java was modified to fix the error handling for setting a chapter as read. Previously, an error message was mistakenly displayed when the operation was successful. Now, it correctly displays the error message when the operation fails.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>