### PR TITLE
Add systemTrayEnabled field in server config

### DIFF
--- a/src/main/resources/server/server.conf
+++ b/src/main/resources/server/server.conf
@@ -1,3 +1,4 @@
 server.ip = "127.0.0.1"
 
 server.webUIEnabled = false
+server.systemTrayEnabled = false


### PR DESCRIPTION
A new field 'server.systemTrayEnabled' has been added to the server configuration file. This field was introduced to make sure the Tray Icon of the UI is the only Tray Icon from this Application.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>