### PR TITLE
Refactor RootView

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/CategoryService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/CategoryService.java
@@ -79,7 +79,7 @@ public class CategoryService {
     try {
       return categoryClient.getCategories(baseUrl);
     } catch (Exception e) {
-      log.error("Failed to get categories", e);
+      log.debug("Failed to get categories", e);
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -166,7 +166,6 @@ public class RootView extends StandardLayout implements BeforeEnterObserver {
                 addCategoryTab(s, c);
               });
 
-
           dialog.open();
         });
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/RootView.java
@@ -10,6 +10,8 @@ import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.TabSheet;
 import com.vaadin.flow.component.tabs.TabSheetVariant;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Route;
 import java.util.List;
 import online.hatsunemiku.tachideskvaadinui.component.card.DraggableMangaCard;
@@ -28,12 +30,13 @@ import org.jetbrains.annotations.NotNull;
 
 @Route("/")
 @CssImport("css/root.css")
-public class RootView extends StandardLayout {
+public class RootView extends StandardLayout implements BeforeEnterObserver {
 
   private TabSheet tabs;
   private final LibUpdateService libUpdateService;
   private final MangaService mangaService;
   private final CategoryService categoryService;
+  private final SettingsService settingsService;
 
   public RootView(
       SettingsService settingsService,
@@ -45,72 +48,7 @@ public class RootView extends StandardLayout {
     this.libUpdateService = libUpdateService;
     this.categoryService = categoryService;
     this.mangaService = mangaService;
-
-    Settings settings = settingsService.getSettings();
-
-    List<Category> categories;
-
-    try {
-      categories = categoryService.getCategories();
-    } catch (Exception e) {
-      UI ui = UI.getCurrent();
-      ui.access(() -> ui.navigate(ServerStartView.class));
-      return;
-    }
-
-    tabs = new TabSheet();
-    tabs.addThemeVariants(TabSheetVariant.LUMO_BORDERED);
-    addCategoryTabs(categories, settings);
-
-    Div buttons = new Div();
-    buttons.setClassName("library-buttons");
-
-    Button createButton = new Button(VaadinIcon.PLUS.create());
-    createButton.addClickListener(
-        e -> {
-          CategoryDialog dialog = new CategoryDialog(categoryService);
-
-          dialog.addOpenedChangeListener(
-              event -> {
-                if (!event.isOpened()) {
-                  removeClassName("blur");
-                } else {
-                  addClassName("blur");
-                }
-              });
-
-          dialog.addOnCategoryCreationListener(
-              event -> {
-                Category c = event.getCategory();
-
-                Settings s = settingsService.getSettings();
-
-                addCategoryTab(s, c);
-              });
-
-          dialog.open();
-        });
-
-    Button refreshButton = new Button(VaadinIcon.REFRESH.create());
-    refreshButton.addClickListener(
-        e -> {
-          boolean success = this.libUpdateService.fetchUpdate();
-          Notification notification;
-          if (!success) {
-            notification = new Notification("Failed to fetch update", 3000);
-            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-          } else {
-            notification = new Notification("Updating library", 3000);
-            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
-          }
-          notification.open();
-        });
-
-    buttons.add(refreshButton, createButton);
-
-    tabs.setSuffixComponent(buttons);
-
-    setContent(tabs);
+    this.settingsService = settingsService;
   }
 
   private void addCategoryTabs(List<Category> categories, Settings settings) {
@@ -175,5 +113,79 @@ public class RootView extends StandardLayout {
       MangaCard card = new DraggableMangaCard(settings, m, c);
       grid.add(card);
     }
+  }
+
+  @Override
+  public void beforeEnter(BeforeEnterEvent event) {
+
+    List<Category> categories;
+
+    try {
+      categories = categoryService.getCategories();
+    } catch (Exception e) {
+      UI ui = UI.getCurrent();
+      ui.access(() -> ui.navigate(ServerStartView.class));
+      return;
+    }
+
+    tabs = new TabSheet();
+    tabs.addThemeVariants(TabSheetVariant.LUMO_BORDERED);
+    addCategoryTabs(categories, settingsService.getSettings());
+
+    Div buttons = getTabSheetButtons();
+    tabs.setSuffixComponent(buttons);
+
+    setContent(tabs);
+  }
+
+  @NotNull
+  private Div getTabSheetButtons() {
+    Div buttons = new Div();
+    buttons.setClassName("library-buttons");
+
+    Button createButton = new Button(VaadinIcon.PLUS.create());
+    createButton.addClickListener(
+        e -> {
+          CategoryDialog dialog = new CategoryDialog(categoryService);
+
+          dialog.addOpenedChangeListener(
+              openedChangeEvent -> {
+                if (!openedChangeEvent.isOpened()) {
+                  removeClassName("blur");
+                } else {
+                  addClassName("blur");
+                }
+              });
+
+          dialog.addOnCategoryCreationListener(
+              categoryCreationEvent -> {
+                Category c = categoryCreationEvent.getCategory();
+
+                Settings s = settingsService.getSettings();
+
+                addCategoryTab(s, c);
+              });
+
+
+          dialog.open();
+        });
+
+    Button refreshButton = new Button(VaadinIcon.REFRESH.create());
+    refreshButton.addClickListener(
+        e -> {
+          boolean success = this.libUpdateService.fetchUpdate();
+          Notification notification;
+          if (!success) {
+            notification = new Notification("Failed to fetch update", 3000);
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+          } else {
+            notification = new Notification("Updating library", 3000);
+            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+          }
+          notification.open();
+        });
+
+    buttons.add(refreshButton, createButton);
+    return buttons;
   }
 }


### PR DESCRIPTION
This commit makes several changes for better code maintenance and user-experience. Firstly, in CategoryService.java, the error log level for getting categories has been lowered to debug. This change is important to reduce unnecessary noise in the error logs as this is not critical and in fact expected, when redirecting to the ServerStartView.

Significant refactoring was done in RootView.java to enhance the readability and maintenance. The view initialization code in the constructor has been moved into the new method "beforeEnter". By leveraging the BeforeEnterObserver interface, we make sure that the view is ready before the user enters it, while avoiding returning prematurely out of the constructor. This also seems to help with Performance when creating the View. Creating the tabSheet buttons are now handled by a separate method getTabSheetButtons() which makes the code cleaner. Also, the SettingsService is now held at an instance level.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>