### PR TITLE
Improve UI responsiveness and update MangaCard link attribute

### DIFF
--- a/frontend/css/components/scroller/source-explore-scroller.css
+++ b/frontend/css/components/scroller/source-explore-scroller.css
@@ -1,10 +1,29 @@
 .explore-scroller-manga-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  grid-gap: 1rem;
+  grid-gap: var(--miku-grid-gap);
   width: 95%;
   margin-right: 0;
   justify-self: center;
+}
+
+
+@media (max-width: 720px) {
+  .explore-scroller-manga-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 500px) {
+  .explore-scroller-manga-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 300px) {
+  .explore-scroller-manga-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .explore-scroller {

--- a/frontend/css/root.css
+++ b/frontend/css/root.css
@@ -1,10 +1,27 @@
 .library-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  grid-gap: 1rem;
+  grid-gap: var(--miku-grid-gap);
   padding: 1rem;
   max-width: 100%;
-  min-height: 50.5vh;
+}
+
+@media (max-width: 720px) {
+  .library-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .library-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 500px) {
+  .library-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .delete-category-button {

--- a/frontend/themes/miku/styles.css
+++ b/frontend/themes/miku/styles.css
@@ -43,6 +43,8 @@ html {
 
   --miku-loading: url(images/loading.svg);
 
+  --miku-grid-gap: 1rem;
+
 
   /*dark*/
   --miku-selected-dark-color: hsl(193, 62%, 29%);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/MangaCard.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/MangaCard.java
@@ -11,6 +11,6 @@ public class MangaCard extends Card {
     super(manga.getTitle(), settings.getUrl() + manga.getThumbnailUrl());
 
     String link = "/manga/" + manga.getId();
-    this.getElement().setAttribute("href", link);
+    setHref(link);
   }
 }


### PR DESCRIPTION
Introduced media queries in source-explore-scroller.css and root.css to ensure UI responsiveness especially on devices with display width less than 720px, 600px, or 500px. This provides better user experience for mobile devices or smaller screen sizes by adjusting the number of columns in explore-scroller-manga-grid and library-grid accordingly.

The href attribute of MangaCard element in MangaCard.java is now set through the setHref function. This makes the code more readable and consistent with best practices.

Also, added grid-gap variable in styles.css for better maintainability of code and possible future enhancements of grid-gap values.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>