### PR TITLE
Update FlowSwiper version to 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     //vaadin directory plugins
     implementation 'in.virit:viritin:2.0.1'
-    implementation 'org.vaadin.addons.online.hatsunemiku.diamond:FlowSwiper:1.3.0'
+    implementation 'org.vaadin.addons.online.hatsunemiku.diamond:FlowSwiper:1.3.1'
 }
 
 dependencyManagement {


### PR DESCRIPTION
In the build.gradle file, the version of FlowSwiper dependency has been updated from 1.3.0 to 1.3.1. This makes a small bugfix for less error's during build/packaging.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>