### PR TITLE
Add manga chapter downloading functionality and style adjustments

### DIFF
--- a/frontend/css/components/chapter-list-box.css
+++ b/frontend/css/components/chapter-list-box.css
@@ -50,3 +50,27 @@
 .chapter-list-box-item-right-side vaadin-button {
   border: none;
 }
+
+.downloading {
+  animation: downloading 5s infinite;
+}
+
+@keyframes downloading {
+  0% {
+    background-position: 0 0;
+    color: var(--miku-background-color-p1);
+    border-color: var(--miku-background-color-p1);
+  }
+
+  50% {
+    background-position: 0 100%;
+    color: var(--miku-background-color-p2);
+    border-color: var(--miku-background-color-p2);
+  }
+
+  100% {
+    background-position: 0 0;
+    color: var(--miku-background-color-p1);
+    border-color: var(--miku-background-color-p1);
+  }
+}

--- a/frontend/themes/miku/styles.css
+++ b/frontend/themes/miku/styles.css
@@ -11,6 +11,9 @@ html {
 
   --lumo-header-text-color: hsl(193, 62%, 89%);
 
+  --miku-background-color-p1: #e12885;
+  --miku-background-color-p2: #137a7f;
+  --miku-background-color-p3: #86cecb;
   --miku-background: linear-gradient(302deg, #e12885, #137a7f, #86cecb);
 
   --miku-highlight-color: rgba(108, 225, 180, 0.5);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -1,10 +1,16 @@
 package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.With;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@With
 @EqualsAndHashCode
 public class Chapter {
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -1,24 +1,32 @@
 package online.hatsunemiku.tachideskvaadinui.services;
 
+import feign.FeignException;
 import java.net.URI;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.data.Settings;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Chapter;
 import online.hatsunemiku.tachideskvaadinui.data.tachidesk.Manga;
+import online.hatsunemiku.tachideskvaadinui.services.client.DownloadClient;
 import online.hatsunemiku.tachideskvaadinui.services.client.MangaClient;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class MangaService {
 
   private final MangaClient mangaClient;
+  //I chose to use the download client here as you only really use it in combination with Manga and not on its own
+  private final DownloadClient downloadClient;
   private final SettingsService settingsService;
 
   @Autowired
-  public MangaService(MangaClient mangaClient, SettingsService settingsService) {
+  public MangaService(MangaClient mangaClient, DownloadClient downloadClient,
+      SettingsService settingsService) {
     this.mangaClient = mangaClient;
+    this.downloadClient = downloadClient;
     this.settingsService = settingsService;
   }
 
@@ -83,7 +91,7 @@ public class MangaService {
   /**
    * Adds a manga to a category.
    *
-   * @param mangaId the ID of the manga to be added
+   * @param mangaId    the ID of the manga to be added
    * @param categoryId the ID of the category to add the manga to
    */
   public void addMangaToCategory(long mangaId, long categoryId) {
@@ -95,7 +103,7 @@ public class MangaService {
   /**
    * Removes a manga from a category.
    *
-   * @param mangaId the ID of the manga to be removed
+   * @param mangaId    the ID of the manga to be removed
    * @param categoryId the ID of the category to remove the manga from
    */
   public void removeMangaFromCategory(long mangaId, long categoryId) {
@@ -121,4 +129,72 @@ public class MangaService {
 
     return URI.create(settings.getUrl());
   }
+
+  /**
+   * Downloads a single chapter of a manga.
+   *
+   * @param mangaId      the ID of the manga to download
+   * @param chapterIndex the index of the chapter to download
+   * @return true if downloading was queued, false otherwise
+   */
+  public boolean downloadSingleChapter(int mangaId, int chapterIndex) {
+    URI baseUrl = getBaseUrl();
+
+    try {
+      downloadClient.downloadSingleChapter(baseUrl, mangaId, chapterIndex);
+      return true;
+    } catch (FeignException e) {
+      log.debug("Failed to download chapter", e);
+      return false;
+    } catch (Exception e) {
+      log.error("Failed to download chapter", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Downloads multiple chapters of manga.
+   *
+   * @param chapterIds the IDs of the chapters to download
+   * @return true if downloading was queued, false otherwise
+   */
+  public boolean downloadMultipleChapter(List<Integer> chapterIds) {
+    URI baseUrl = getBaseUrl();
+
+    try {
+      var tempList = List.copyOf(chapterIds);
+      var request = new DownloadClient.DownloadChapterRequest(tempList);
+      downloadClient.downloadMultipleChapters(baseUrl, request);
+      return true;
+    } catch (FeignException e) {
+      log.debug("Failed to download chapter", e);
+      return false;
+    } catch (Exception e) {
+      log.error("Failed to download chapter", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Deletes a single chapter of manga.
+   *
+   * @param mangaId      the ID of the manga
+   * @param chapterIndex the index of the chapter to delete
+   * @return true if deletion was successful, false otherwise
+   */
+  public boolean deleteSingleChapter(int mangaId, int chapterIndex) {
+    URI baseUrl = getBaseUrl();
+
+    try {
+      downloadClient.deleteSingleChapter(baseUrl, mangaId, chapterIndex);
+      return true;
+    } catch (FeignException e) {
+      log.debug("Failed to delete chapter", e);
+      return false;
+    } catch (Exception e) {
+      log.error("Failed to delete chapter", e);
+      throw new RuntimeException(e);
+    }
+  }
+
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -18,13 +18,14 @@ import org.springframework.stereotype.Service;
 public class MangaService {
 
   private final MangaClient mangaClient;
-  //I chose to use the download client here as you only really use it in combination with Manga and not on its own
+  // I chose to use the download client here as you only really use it in combination with Manga and
+  // not on its own
   private final DownloadClient downloadClient;
   private final SettingsService settingsService;
 
   @Autowired
-  public MangaService(MangaClient mangaClient, DownloadClient downloadClient,
-      SettingsService settingsService) {
+  public MangaService(
+      MangaClient mangaClient, DownloadClient downloadClient, SettingsService settingsService) {
     this.mangaClient = mangaClient;
     this.downloadClient = downloadClient;
     this.settingsService = settingsService;
@@ -91,7 +92,7 @@ public class MangaService {
   /**
    * Adds a manga to a category.
    *
-   * @param mangaId    the ID of the manga to be added
+   * @param mangaId the ID of the manga to be added
    * @param categoryId the ID of the category to add the manga to
    */
   public void addMangaToCategory(long mangaId, long categoryId) {
@@ -103,7 +104,7 @@ public class MangaService {
   /**
    * Removes a manga from a category.
    *
-   * @param mangaId    the ID of the manga to be removed
+   * @param mangaId the ID of the manga to be removed
    * @param categoryId the ID of the category to remove the manga from
    */
   public void removeMangaFromCategory(long mangaId, long categoryId) {
@@ -133,7 +134,7 @@ public class MangaService {
   /**
    * Downloads a single chapter of a manga.
    *
-   * @param mangaId      the ID of the manga to download
+   * @param mangaId the ID of the manga to download
    * @param chapterIndex the index of the chapter to download
    * @return true if downloading was queued, false otherwise
    */
@@ -178,7 +179,7 @@ public class MangaService {
   /**
    * Deletes a single chapter of manga.
    *
-   * @param mangaId      the ID of the manga
+   * @param mangaId the ID of the manga
    * @param chapterIndex the index of the chapter to delete
    * @return true if deletion was successful, false otherwise
    */
@@ -196,5 +197,4 @@ public class MangaService {
       throw new RuntimeException(e);
     }
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/DownloadClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/DownloadClient.java
@@ -1,0 +1,53 @@
+package online.hatsunemiku.tachideskvaadinui.services.client;
+
+import java.net.URI;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "download", url = "localhost:8080")
+public interface DownloadClient {
+
+  /**
+   * Downloads a single chapter of a manga from a specified base URL.
+   *
+   * @param baseUrl      the base URL of the manga server
+   * @param mangaId      the ID of the manga
+   * @param chapterIndex the index of the chapter to download
+   */
+  @GetMapping("/api/v1/download/{mangaId}/chapter/{chapterIndex}")
+  void downloadSingleChapter(URI baseUrl, @PathVariable int mangaId, @PathVariable int chapterIndex);
+
+  /**
+   * Downloads multiple chapters of a manga from a specified base URL.
+   *
+   * @param baseUrl         the base URL of the manga server
+   * @param downloadRequest the request containing the IDs of the chapters to download
+   */
+  @PostMapping("/api/v1/download/batch")
+  void downloadMultipleChapters(URI baseUrl, @RequestBody DownloadChapterRequest downloadRequest);
+
+  //http://localhost:4567/api/v1/manga/4687/chapter/1
+  @DeleteMapping("/api/v1/manga/{mangaId}/chapter/{chapterIndex}")
+  void deleteSingleChapter(URI baseUrl, @PathVariable int mangaId, @PathVariable int chapterIndex);
+
+  /**
+   * Represents a request to download chapters.
+   * <p>
+   * The {@code DownloadChapterRequest} class is a data class that encapsulates the chapter IDs to be downloaded.
+   * It is used to communicate between the TachideskUI backend and the Tachidesk Server.
+   * </p>
+   */
+  @Data
+  @AllArgsConstructor
+  class DownloadChapterRequest {
+
+    private List<Integer> chapterIds;
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/DownloadClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/DownloadClient.java
@@ -17,32 +17,33 @@ public interface DownloadClient {
   /**
    * Downloads a single chapter of a manga from a specified base URL.
    *
-   * @param baseUrl      the base URL of the manga server
-   * @param mangaId      the ID of the manga
+   * @param baseUrl the base URL of the manga server
+   * @param mangaId the ID of the manga
    * @param chapterIndex the index of the chapter to download
    */
   @GetMapping("/api/v1/download/{mangaId}/chapter/{chapterIndex}")
-  void downloadSingleChapter(URI baseUrl, @PathVariable int mangaId, @PathVariable int chapterIndex);
+  void downloadSingleChapter(
+      URI baseUrl, @PathVariable int mangaId, @PathVariable int chapterIndex);
 
   /**
    * Downloads multiple chapters of a manga from a specified base URL.
    *
-   * @param baseUrl         the base URL of the manga server
+   * @param baseUrl the base URL of the manga server
    * @param downloadRequest the request containing the IDs of the chapters to download
    */
   @PostMapping("/api/v1/download/batch")
   void downloadMultipleChapters(URI baseUrl, @RequestBody DownloadChapterRequest downloadRequest);
 
-  //http://localhost:4567/api/v1/manga/4687/chapter/1
+  // http://localhost:4567/api/v1/manga/4687/chapter/1
   @DeleteMapping("/api/v1/manga/{mangaId}/chapter/{chapterIndex}")
   void deleteSingleChapter(URI baseUrl, @PathVariable int mangaId, @PathVariable int chapterIndex);
 
   /**
    * Represents a request to download chapters.
-   * <p>
-   * The {@code DownloadChapterRequest} class is a data class that encapsulates the chapter IDs to be downloaded.
-   * It is used to communicate between the TachideskUI backend and the Tachidesk Server.
-   * </p>
+   *
+   * <p>The {@code DownloadChapterRequest} class is a data class that encapsulates the chapter IDs
+   * to be downloaded. It is used to communicate between the TachideskUI backend and the Tachidesk
+   * Server.
    */
   @Data
   @AllArgsConstructor

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -129,25 +129,26 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
   private Button getDownloadBtn(List<Chapter> chapters) {
     Button downloadBtn = new Button("Download", LumoIcon.DOWNLOAD.create());
     downloadBtn.addClassName("manga-btn");
-    downloadBtn.addClickListener(e -> {
-      var ids = chapters.stream().map(Chapter::getId).toList();
+    downloadBtn.addClickListener(
+        e -> {
+          var ids = chapters.stream().map(Chapter::getId).toList();
 
-      if (!mangaService.downloadMultipleChapter(ids)) {
-        Notification notification = new Notification("Failed to download chapters", 3000);
-        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
-        notification.setPosition(Notification.Position.MIDDLE);
-        notification.open();
-        return;
-      }
+          if (!mangaService.downloadMultipleChapter(ids)) {
+            Notification notification = new Notification("Failed to download chapters", 3000);
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+            notification.setPosition(Notification.Position.MIDDLE);
+            notification.open();
+            return;
+          }
 
-      UI ui = UI.getCurrent();
-      ComponentUtil.fireEvent(ui, new DownloadAllChapterEvent(this, false));
+          UI ui = UI.getCurrent();
+          ComponentUtil.fireEvent(ui, new DownloadAllChapterEvent(this, false));
 
-      Notification notification = new Notification("Downloading chapters", 3000);
-      notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
-      notification.setPosition(Notification.Position.MIDDLE);
-      notification.open();
-    });
+          Notification notification = new Notification("Downloading chapters", 3000);
+          notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+          notification.setPosition(Notification.Position.MIDDLE);
+          notification.open();
+        });
     return downloadBtn;
   }
 
@@ -155,7 +156,7 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
    * Creates and retrieves the resume button for a manga, which allows the user to resume reading
    * from the last chapter they left off.
    *
-   * @param manga    The manga object for which to retrieve the resume button.
+   * @param manga The manga object for which to retrieve the resume button.
    * @param chapters The list of chapters available for the manga.
    * @return The resume button with the appropriate click listener.
    */
@@ -222,16 +223,15 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     return libraryBtn;
   }
 
-
   public static class DownloadAllChapterEvent extends ComponentEvent<MangaView> {
 
     /**
      * Creates a new event using the given source and indicator whether the event originated from
      * the client side or the server side.
      *
-     * @param source     the source component
-     * @param fromClient <code>true</code> if the event originated from the client
-     *                   side, <code>false</code> otherwise
+     * @param source the source component
+     * @param fromClient <code>true</code> if the event originated from the client side, <code>false
+     *     </code> otherwise
      */
     public DownloadAllChapterEvent(MangaView source, boolean fromClient) {
       super(source, fromClient);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/MangaView.java
@@ -1,5 +1,7 @@
 package online.hatsunemiku.tachideskvaadinui.view;
 
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.CssImport;
@@ -106,6 +108,8 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
     Button libraryBtn = getLibraryBtn(manga);
     libraryBtn.addClassName("manga-btn");
 
+    Button downloadBtn = getDownloadBtn(chapters);
+
     Button trackBtn = new Button("Tracking", LumoIcon.RELOAD.create());
     trackBtn.addClassName("manga-btn");
 
@@ -117,15 +121,41 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
 
     Button resumeBtn = getResumeButton(manga, chapters);
 
-    buttons.add(libraryBtn, resumeBtn, trackBtn);
+    buttons.add(libraryBtn, resumeBtn, downloadBtn, trackBtn);
     return buttons;
+  }
+
+  @NotNull
+  private Button getDownloadBtn(List<Chapter> chapters) {
+    Button downloadBtn = new Button("Download", LumoIcon.DOWNLOAD.create());
+    downloadBtn.addClassName("manga-btn");
+    downloadBtn.addClickListener(e -> {
+      var ids = chapters.stream().map(Chapter::getId).toList();
+
+      if (!mangaService.downloadMultipleChapter(ids)) {
+        Notification notification = new Notification("Failed to download chapters", 3000);
+        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+        notification.setPosition(Notification.Position.MIDDLE);
+        notification.open();
+        return;
+      }
+
+      UI ui = UI.getCurrent();
+      ComponentUtil.fireEvent(ui, new DownloadAllChapterEvent(this, false));
+
+      Notification notification = new Notification("Downloading chapters", 3000);
+      notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+      notification.setPosition(Notification.Position.MIDDLE);
+      notification.open();
+    });
+    return downloadBtn;
   }
 
   /**
    * Creates and retrieves the resume button for a manga, which allows the user to resume reading
    * from the last chapter they left off.
    *
-   * @param manga The manga object for which to retrieve the resume button.
+   * @param manga    The manga object for which to retrieve the resume button.
    * @param chapters The list of chapters available for the manga.
    * @return The resume button with the appropriate click listener.
    */
@@ -190,5 +220,21 @@ public class MangaView extends StandardLayout implements BeforeEnterObserver {
       libraryBtn.setText("Add to library");
     }
     return libraryBtn;
+  }
+
+
+  public static class DownloadAllChapterEvent extends ComponentEvent<MangaView> {
+
+    /**
+     * Creates a new event using the given source and indicator whether the event originated from
+     * the client side or the server side.
+     *
+     * @param source     the source component
+     * @param fromClient <code>true</code> if the event originated from the client
+     *                   side, <code>false</code> otherwise
+     */
+    public DownloadAllChapterEvent(MangaView source, boolean fromClient) {
+      super(source, fromClient);
+    }
   }
 }


### PR DESCRIPTION
This commit introduces the ability for users to download individual and multiple manga chapters. The DownloadClient.java responsible for this functionality has been implemented along with necessary changes in MangaService.java and MangaView.java. To track the download status, asynchronous tracking has been added in ChapterRenderer.java.

In terms of visual changes, download and delete buttons have been added in the chapter list items, with corresponding CSS animations for downloading status. Moreover, minor adjustments were made in the styles.css file and chapter-list-box.css to improve overall UI.

The rationale behind this feature is to enhance the user experience by providing offline access to manga chapters.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>