### PR TITLE
Manga Caching and Library Updates

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/TachideskVaadinUiApplication.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/TachideskVaadinUiApplication.java
@@ -6,14 +6,18 @@ import com.vaadin.flow.theme.Theme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @Push
 @Theme("miku")
 @EnableFeignClients
 @EnableAsync
+@EnableCaching
+@EnableScheduling
 public class TachideskVaadinUiApplication implements AppShellConfigurator {
 
   public static void main(String[] args) {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/config/CacheConfig.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/config/CacheConfig.java
@@ -17,9 +17,8 @@ public class CacheConfig implements CacheManagerCustomizer<CaffeineCacheManager>
 
     Duration expiry = Duration.ofMinutes(10);
 
-    Caffeine<Object, Object> cache = Caffeine.newBuilder()
-        .maximumSize(1000)
-        .expireAfterWrite(expiry);
+    Caffeine<Object, Object> cache =
+        Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(expiry);
 
     cacheManager.setCaffeine(cache);
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/config/CacheConfig.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/config/CacheConfig.java
@@ -1,7 +1,7 @@
 package online.hatsunemiku.tachideskvaadinui.config;
 
-import com.github.benmanes.caffeine.cache.CaffeineSpec;
-import java.util.List;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
 import org.springframework.boot.autoconfigure.cache.CacheManagerCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
@@ -13,10 +13,14 @@ public class CacheConfig implements CacheManagerCustomizer<CaffeineCacheManager>
 
   @Override
   public void customize(CaffeineCacheManager cacheManager) {
-    cacheManager.setCacheNames(List.of("extensions"));
+    cacheManager.setAllowNullValues(false);
 
-    CaffeineSpec spec = CaffeineSpec.parse("maximumSize=1500,expireAfterWrite=30m");
+    Duration expiry = Duration.ofMinutes(10);
 
-    cacheManager.setCaffeineSpec(spec);
+    Caffeine<Object, Object> cache = Caffeine.newBuilder()
+        .maximumSize(1000)
+        .expireAfterWrite(expiry);
+
+    cacheManager.setCaffeine(cache);
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/LibUpdateService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/LibUpdateService.java
@@ -1,10 +1,15 @@
 package online.hatsunemiku.tachideskvaadinui.services;
 
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 import online.hatsunemiku.tachideskvaadinui.services.client.LibUpdateClient;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class LibUpdateService {
 
   private final SettingsService settingsService;
@@ -15,6 +20,7 @@ public class LibUpdateService {
     this.client = client;
   }
 
+  @CacheEvict(value = {"manga"}, allEntries = true)
   public boolean fetchUpdate() {
     var settings = settingsService.getSettings();
 
@@ -23,5 +29,16 @@ public class LibUpdateService {
     var response = client.fetchUpdate(baseUrl);
 
     return response.getStatusCode().is2xxSuccessful();
+  }
+
+  @Scheduled(initialDelay = 1, fixedRate = 10, timeUnit = TimeUnit.MINUTES)
+  protected void scheduledUpdate() {
+    boolean success = fetchUpdate();
+
+    if (success) {
+      log.info("Library update started");
+    } else {
+      log.debug("Could not start library update");
+    }
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/LibUpdateService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/LibUpdateService.java
@@ -20,7 +20,9 @@ public class LibUpdateService {
     this.client = client;
   }
 
-  @CacheEvict(value = {"manga"}, allEntries = true)
+  @CacheEvict(
+      value = {"manga"},
+      allEntries = true)
   public boolean fetchUpdate() {
     var settings = settingsService.getSettings();
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -11,6 +11,7 @@ import online.hatsunemiku.tachideskvaadinui.services.client.DownloadClient;
 import online.hatsunemiku.tachideskvaadinui.services.client.MangaClient;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -49,6 +50,7 @@ public class MangaService {
     return mangaClient.getChapterList(baseUrl, mangaId);
   }
 
+  @Cacheable(value = "chapter", key = "#mangaId + #chapterIndex")
   public Chapter getChapter(long mangaId, int chapterIndex) {
     URI baseUrl = getBaseUrl();
 
@@ -83,6 +85,7 @@ public class MangaService {
    * @param mangaId the ID of the manga to retrieve
    * @return a Manga object containing the full data of the manga
    */
+  @Cacheable(value = "manga", key = "#mangaId")
   public Manga getMangaFull(long mangaId) {
     URI baseUrl = getBaseUrl();
 


### PR DESCRIPTION
This commit adds caching for both the Chapter and Manga data in the MangaService to improve data retrieval performance. The cache is configured with the Caffeine library with a maximum size of 1000 and an expiry of 10 minutes after write to prevent cache bloating. Furthermore, scheduled updating of the library every 10 minutes has been implemented in the LibUpdateService. Caching and updating intervals are added to mitigate the need for constant direct requests, improving the overall responsiveness of the application.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>