### PR TITLE
Add AniList integration to Manga search feature

### DIFF
--- a/frontend/css/views/anilist.css
+++ b/frontend/css/views/anilist.css
@@ -1,0 +1,25 @@
+.anilist-title-section {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  background-color: var(--miku-unselected-color);
+  color: var(--miku-main-color);
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+  padding: 0.2rem;
+  border-radius: 0.5rem;
+}
+
+.anilist-content {
+  width: 100%;
+  padding: 0.6rem;
+  border: 2px solid var(--miku-main-color);
+  border-radius: 0.5rem;
+}
+
+.anilist-content-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(200px, 1fr));
+  grid-gap: 1rem;
+}

--- a/frontend/css/views/search-view.css
+++ b/frontend/css/views/search-view.css
@@ -48,3 +48,10 @@
   min-width: 1.5rem;
   margin-left: 2rem;
 }
+
+.search-btn-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 1rem;
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/AniListMediaCard.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/card/AniListMediaCard.java
@@ -1,0 +1,32 @@
+package online.hatsunemiku.tachideskvaadinui.component.card;
+
+import online.hatsunemiku.tachideskvaadinui.data.tracking.anilist.AniListMedia;
+
+public class AniListMediaCard extends Card {
+
+  public AniListMediaCard(AniListMedia media) {
+    super(getTitle(media), media.coverImage().large());
+
+    setHref("/search/" + getTitle(media));
+  }
+
+  private static String getTitle(AniListMedia media) {
+    var title = media.title();
+
+    String titleString = title.userPreferred();
+
+    if (titleString == null) {
+      titleString = title.enlgish();
+    }
+
+    if (titleString == null) {
+      titleString = title.romaji();
+    }
+
+    if (titleString == null) {
+      titleString = title.native_();
+    }
+
+    return titleString;
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tracking/anilist/MangaList.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tracking/anilist/MangaList.java
@@ -6,4 +6,12 @@ public record MangaList(List<AniListMedia> reading, List<AniListMedia> planToRea
                         List<AniListMedia> completed, List<AniListMedia> onHold,
                         List<AniListMedia> dropped) {
 
+  public MangaList(List<AniListMedia> reading, List<AniListMedia> planToRead,
+      List<AniListMedia> completed, List<AniListMedia> onHold, List<AniListMedia> dropped) {
+    this.reading = List.copyOf(reading);
+    this.planToRead = List.copyOf(planToRead);
+    this.completed = List.copyOf(completed);
+    this.onHold = List.copyOf(onHold);
+    this.dropped = List.copyOf(dropped);
+  }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tracking/anilist/MangaList.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tracking/anilist/MangaList.java
@@ -1,0 +1,9 @@
+package online.hatsunemiku.tachideskvaadinui.data.tracking.anilist;
+
+import java.util.List;
+
+public record MangaList(List<AniListMedia> reading, List<AniListMedia> planToRead,
+                        List<AniListMedia> completed, List<AniListMedia> onHold,
+                        List<AniListMedia> dropped) {
+
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tracking/anilist/MangaList.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tracking/anilist/MangaList.java
@@ -2,12 +2,19 @@ package online.hatsunemiku.tachideskvaadinui.data.tracking.anilist;
 
 import java.util.List;
 
-public record MangaList(List<AniListMedia> reading, List<AniListMedia> planToRead,
-                        List<AniListMedia> completed, List<AniListMedia> onHold,
-                        List<AniListMedia> dropped) {
+public record MangaList(
+    List<AniListMedia> reading,
+    List<AniListMedia> planToRead,
+    List<AniListMedia> completed,
+    List<AniListMedia> onHold,
+    List<AniListMedia> dropped) {
 
-  public MangaList(List<AniListMedia> reading, List<AniListMedia> planToRead,
-      List<AniListMedia> completed, List<AniListMedia> onHold, List<AniListMedia> dropped) {
+  public MangaList(
+      List<AniListMedia> reading,
+      List<AniListMedia> planToRead,
+      List<AniListMedia> completed,
+      List<AniListMedia> onHold,
+      List<AniListMedia> dropped) {
     this.reading = List.copyOf(reading);
     this.planToRead = List.copyOf(planToRead);
     this.completed = List.copyOf(completed);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/AniListAPIService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/AniListAPIService.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -712,7 +713,7 @@ public class AniListAPIService {
     int listSize = lists.length();
 
     List<AniListMedia> completed = null;
-    List<AniListMedia> reading = null;
+    List<AniListMedia> reading = new ArrayList<>();
     List<AniListMedia> dropped = null;
     List<AniListMedia> onHold = null;
     List<AniListMedia> planToRead = null;
@@ -743,10 +744,11 @@ public class AniListAPIService {
 
         switch (status) {
           case COMPLETED -> completed = tempList;
-          case CURRENT -> reading = tempList;
+          case CURRENT, REPEATING -> reading.addAll(tempList);
           case DROPPED -> dropped = tempList;
           case PAUSED -> onHold = tempList;
           case PLANNING -> planToRead = tempList;
+          default -> log.warn("Unknown status: {}", status);
         }
 
       } catch (JsonProcessingException e) {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/AniListAPIService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/AniListAPIService.java
@@ -51,9 +51,8 @@ public class AniListAPIService {
    * dependencies.
    *
    * @param dataService the TrackingDataService object to be used for retrieving and updating the
-   *                    AniList token and manga trackers
-   * @param mapper      the ObjectMapper object to be used for serializing and deserializing JSON
-   *                    data.
+   *     AniList token and manga trackers
+   * @param mapper the ObjectMapper object to be used for serializing and deserializing JSON data.
    */
   public AniListAPIService(TrackingDataService dataService, ObjectMapper mapper) {
     this.dataService = dataService;
@@ -71,7 +70,7 @@ public class AniListAPIService {
    * Retrieves the AniList token from the settings.
    *
    * @return an Optional containing the AniList token if it is present, otherwise returns an empty
-   * Optional
+   *     Optional
    */
   private Optional<OAuthData> getAniListToken() {
     TrackerTokens trackerTokens = dataService.getTokens();
@@ -97,7 +96,7 @@ public class AniListAPIService {
    *
    * @return the AniList token header as a string
    * @throws IllegalStateException if there is no AniList token available or if the token is not
-   *                               valid.
+   *     valid.
    */
   private String getAniListTokenHeader() {
     if (!hasAniListToken()) {
@@ -184,7 +183,7 @@ public class AniListAPIService {
    *
    * @return The current user's ID
    * @throws RuntimeException If no AniList token is available or if there is an error retrieving
-   *                          the user ID
+   *     the user ID
    */
   private int getCurrentUserId() {
     if (!hasAniListToken()) {
@@ -660,11 +659,12 @@ public class AniListAPIService {
    * Retrieves the user's manga list.
    *
    * @return The manga list containing the user's reading, plan to read, completed, on hold, and
-   * dropped manga
+   *     dropped manga
    * @throws RuntimeException If an error occurs while retrieving the manga list
    */
   public MangaList getMangaList() {
-    String query = """
+    String query =
+        """
         query ($userId: Int) {
           MediaListCollection(userId: $userId, type: MANGA) {
             lists {
@@ -701,7 +701,8 @@ public class AniListAPIService {
         }
         """;
 
-    String variables = """
+    String variables =
+        """
         {
           "userId": %s
         }
@@ -726,8 +727,7 @@ public class AniListAPIService {
     for (int i = 0; i < listSize; i++) {
       var list = lists.getObject(i).getArray("entries");
 
-      var typeRef = new TypeReference<List<AniListMedia>>() {
-      };
+      var typeRef = new TypeReference<List<AniListMedia>>() {};
       try {
         for (int j = 0; j < list.length(); j++) {
           replaceMediaWithImageAndTitle(list, j);
@@ -762,16 +762,16 @@ public class AniListAPIService {
    * Replaces the "media" object in a JsonArray with "coverImage" and "title" objects.
    *
    * @param list The JsonArray containing the media object to be replaced
-   * @param j    The index of the media object within the JsonArray
+   * @param j The index of the media object within the JsonArray
    */
   private void replaceMediaWithImageAndTitle(JsonArray list, int j) {
     var media = list.getObject(j).getObject("media");
     var coverImage = media.getObject("coverImage");
     var title = media.getObject("title");
 
-    //remove media from object
+    // remove media from object
     list.getObject(j).remove("media");
-    //add back the two keys
+    // add back the two keys
     list.getObject(j).put("coverImage", coverImage);
     list.getObject(j).put("title", title);
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/AniListAPIService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/AniListAPIService.java
@@ -762,10 +762,6 @@ public class AniListAPIService {
       completed = List.of();
     }
 
-    if (reading == null) {
-      reading = List.of();
-    }
-
     if (dropped == null) {
       dropped = List.of();
     }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/AniListView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/AniListView.java
@@ -1,0 +1,64 @@
+package online.hatsunemiku.tachideskvaadinui.view;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import java.util.List;
+import online.hatsunemiku.tachideskvaadinui.component.card.AniListMediaCard;
+import online.hatsunemiku.tachideskvaadinui.data.tracking.anilist.AniListMedia;
+import online.hatsunemiku.tachideskvaadinui.data.tracking.anilist.MangaList;
+import online.hatsunemiku.tachideskvaadinui.services.AniListAPIService;
+import online.hatsunemiku.tachideskvaadinui.view.layout.StandardLayout;
+
+@Route("anilist")
+@CssImport("./css/views/anilist.css")
+public class AniListView extends StandardLayout {
+  public AniListView(AniListAPIService apiService) {
+    super("AniList");
+    if (!apiService.hasAniListToken()) {
+      Button authBtn = new Button("Authenticate");
+      authBtn.addClickListener(e -> {
+        String url = apiService.getAniListAuthUrl();
+        getUI().ifPresent(ui -> ui.getPage().open(url));
+      });
+
+      add(authBtn);
+      return;
+    }
+
+    MangaList list = apiService.getMangaList();
+
+    VerticalLayout content = new VerticalLayout();
+
+    var reading = getContentSection("Reading", list.reading());
+    var planToRead = getContentSection("Plan to read", list.planToRead());
+    var completed = getContentSection("Completed", list.completed());
+    var onHold = getContentSection("On hold", list.onHold());
+    var dropped = getContentSection("Dropped", list.dropped());
+
+    content.add(reading, planToRead, completed, onHold, dropped);
+
+    setContent(content);
+  }
+
+  private Div getContentSection(String title, List<AniListMedia> media) {
+    Div section = new Div();
+    section.addClassName("anilist-content");
+
+    Div titleSection = new Div();
+    titleSection.addClassName("anilist-title-section");
+    titleSection.setText(title);
+
+    Div contentGrid = new Div();
+    contentGrid.addClassName("anilist-content-grid");
+
+    for (AniListMedia manga : media) {
+      contentGrid.add(new AniListMediaCard(manga));
+    }
+
+    section.add(titleSection, contentGrid);
+    return section;
+  }
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/SearchView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/SearchView.java
@@ -3,12 +3,17 @@ package online.hatsunemiku.tachideskvaadinui.view;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.Svg;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
 import com.vaadin.flow.router.Route;
 import feign.FeignException;
 import java.io.IOException;
@@ -40,7 +45,7 @@ import org.vaadin.miki.superfields.text.SuperTextField;
 @CssImport("./css/views/search-view.css")
 @Slf4j
 @Route("search")
-public class SearchView extends StandardLayout {
+public class SearchView extends StandardLayout implements HasUrlParameter<String> {
 
   private final Div searchResults;
   private final LangComboBox langFilter;
@@ -64,9 +69,31 @@ public class SearchView extends StandardLayout {
     this.searchField = searchField;
     this.langFilter = langFilter;
 
+    Div btnContainer = new Div();
+    btnContainer.addClassName("search-btn-container");
+
+    Button importBtn = new Button("Import from AniList", VaadinIcon.DOWNLOAD.create());
+    importBtn.addClickListener(e -> {
+      UI ui = UI.getCurrent();
+
+      if (ui == null) {
+        if (getUI().isEmpty()) {
+          log.error("UI is not present");
+          return;
+        }
+
+        ui = getUI().get();
+      }
+
+      ui.navigate(AniListView.class);
+    });
+
+    btnContainer.add(importBtn);
+
     Div content = new Div();
     content.setClassName("search-content");
 
+    content.add(btnContainer);
     content.add(searchField);
     content.add(langFilter);
     content.add(searchResults);
@@ -177,7 +204,7 @@ public class SearchView extends StandardLayout {
   /**
    * Adds a search result to the user interface.
    *
-   * @param source the source of the search result
+   * @param source    the source of the search result
    * @param mangaList the list of manga from the search result
    * @return true if the search result was successfully added, otherwise false
    */
@@ -318,5 +345,15 @@ public class SearchView extends StandardLayout {
     if (!addSearchResultToUI(source, mangaList)) {
       log.error("Failed to add search result to UI for source {}", source.getDisplayName());
     }
+  }
+
+  @Override
+  public void setParameter(BeforeEvent event, @OptionalParameter String query) {
+    if (query == null) {
+      return;
+    }
+
+    searchField.setValue(query);
+    runSearch(searchField);
   }
 }


### PR DESCRIPTION
This commit introduces a new AniList view and related classes, which enable users to search for Manga from their AniList Manga List. A new button was added to the SearchView that allows navigation to the new AniList view for importing Manga. This feature facilitates an easier and less time-consuming way for users to migrate and track Manga from their AniList account.